### PR TITLE
Move entry points declaration to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,10 @@ include_package_data = True
 exclude=
     _datalad_buildsupport
 
+[options.entry_points]
+datalad.extensions =
+    fuse = datalad_fuse:command_suite
+
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,4 @@ if __name__ == "__main__":
         version=versioneer.get_version(),
         cmdclass=cmdclass,
         setup_requires=SETUP_REQUIRES,
-        entry_points={
-            # 'datalad.extensions' is THE entrypoint inspected by the datalad
-            # API builders
-            "datalad.extensions": [
-                # the label in front of '=' is the command suite label
-                # the entrypoint can point to any symbol of any name, as long it is
-                # valid datalad interface specification (see demo in this extensions
-                "fuse=datalad_fuse:command_suite",
-            ],
-        },
     )


### PR DESCRIPTION
In order to keep all of the packaging information together in one file.