### PR TITLE
RF/ENH: initial prototype for --mode-transparent (not hiding .git)

### DIFF
--- a/datalad_fuse/__init__.py
+++ b/datalad_fuse/__init__.py
@@ -78,7 +78,12 @@ class FuseFS(Interface):
             args=("-f", "--foreground"),
             action="store_true",
             doc="""Run process in foreground [required].""",
-        )
+        ),
+        "mode_transparent": Parameter(
+            args=("--mode-transparent",),
+            action="store_true",
+            doc="Expose .git directory",
+        ),
         # TODO: (might better become config vars?)
         # --cache=persist
         # --recursive=follow,get - encountering submodule might install it first
@@ -89,7 +94,10 @@ class FuseFS(Interface):
     @datasetmethod(name="fusefs")
     @eval_results
     def __call__(
-        mount_path: str, dataset: Optional[Dataset] = None, foreground: bool = False
+        mount_path: str,
+        dataset: Optional[Dataset] = None,
+        foreground: bool = False,
+        mode_transparent: bool = False,
     ) -> Iterator[Dict[str, Any]]:
         if not foreground:
             yield get_status_dict(
@@ -103,7 +111,7 @@ class FuseFS(Interface):
             dataset, purpose="mount as FUSE system", check_installed=True
         )
         FUSE(
-            DataLadFUSE(ds.path),
+            DataLadFUSE(ds.path, mode_transparent=mode_transparent),
             mount_path,
             foreground=foreground,
             # , allow_other=True

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -50,11 +50,12 @@ class DatasetAdapter:
         lgr.debug("get_file_state: %s", relpath)
 
         # Shortcut handling of content under .git, in particular - annex key paths
-        if relpath.startswith('.git/'):
-            # TODO: 6 is hardcoded but AFAIK and unfortunately annex does not support
-            # any layout which would have some other number of directories there. Nevertheless
-            # we might want to avoid relying on hardcoding 6 here?!
-            if relpath.startswith('.git/annex/objects/') and relpath.count('/') == 6:
+        if relpath.startswith(".git/"):
+            # TODO: 6 is hardcoded but AFAIK and unfortunately annex does not
+            # support any layout which would have some other number of
+            # directories there. Nevertheless we might want to avoid relying on
+            # hardcoding 6 here?!
+            if relpath.startswith(".git/annex/objects/") and relpath.count("/") == 6:
                 if p.exists():
                     return (FileState.HAS_CONTENT, p.name)
                 else:

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -47,6 +47,20 @@ class DatasetAdapter:
     @lru_cache(maxsize=CACHE_SIZE)
     def get_file_state(self, relpath: str) -> Tuple[FileState, Optional[str]]:
         p = self.path / relpath
+        lgr.debug("get_file_state: %s", relpath)
+
+        # Shortcut handling of content under .git, in particular - annex key paths
+        if relpath.startswith('.git/'):
+            # TODO: 6 is hardcoded but AFAIK and unfortunately annex does not support
+            # any layout which would have some other number of directories there. Nevertheless
+            # we might want to avoid relying on hardcoding 6 here?!
+            if relpath.startswith('.git/annex/objects/') and relpath.count('/') == 6:
+                if p.exists():
+                    return (FileState.HAS_CONTENT, p.name)
+                else:
+                    return (FileState.NO_CONTENT, p.name)
+            return (FileState.NOT_ANNEXED, None)
+
         if not p.is_symlink():
             if p.stat().st_size < 1024 and self.annex is not None:
                 if self.annex.is_under_annex(relpath, batch=True):
@@ -67,9 +81,12 @@ class DatasetAdapter:
         else:
             return (FileState.NO_CONTENT, key)
 
-    def get_urls(self, filepath: Union[str, Path], key: str) -> Iterator[str]:
+    def get_urls(self, key: str) -> Iterator[str]:
         assert self.annex is not None
-        whereis = self.annex.whereis(str(filepath), output="full", batch=True)
+        # TODO: switch to batch=True whenever
+        # https://github.com/datalad/datalad/pull/6379 is merged/released.
+        # Will need a recent git-annex to work!
+        whereis = self.annex.whereis(key, output="full", batch=False, key=True)
         remote_uuids = []
         for ru, v in whereis.items():
             remote_uuids.append(ru)
@@ -141,7 +158,7 @@ class DatasetAdapter:
             )
         if fstate is FileState.NO_CONTENT:
             lgr.debug("%s: opening via fsspec", relpath)
-            for url in self.get_urls(relpath, key):
+            for url in self.get_urls(key):
                 try:
                     lgr.debug("%s: Attempting to open via URL %s", relpath, url)
                     return self.fs.open(url, mode, **kwargs)
@@ -181,6 +198,8 @@ class FsspecAdapter:
         self.datasets.clear()
 
     @lru_cache(maxsize=CACHE_SIZE)
+    # TODO: optimize "caching" more since for all files under the same directory
+    # they all would belong to the same dataset
     def get_dataset_path(self, path: Union[str, Path]) -> Path:
         path = Path(self.root, path)
         dspath = get_dataset_root(path)

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -57,9 +57,9 @@ class DatasetAdapter:
             # hardcoding 6 here?!
             if relpath.startswith(".git/annex/objects/") and relpath.count("/") == 6:
                 if p.exists():
-                    return (FileState.HAS_CONTENT, p.name)
+                    return (FileState.HAS_CONTENT, filename2key(p.name))
                 else:
-                    return (FileState.NO_CONTENT, p.name)
+                    return (FileState.NO_CONTENT, filename2key(p.name))
             return (FileState.NOT_ANNEXED, None)
 
         if not p.is_symlink():
@@ -76,7 +76,7 @@ class DatasetAdapter:
             target.relative_to(self.path / ".git" / "annex" / "objects")
         except ValueError:
             return (FileState.NOT_ANNEXED, None)
-        key = target.name
+        key = filename2key(target.name)
         if target.exists():
             return (FileState.HAS_CONTENT, key)
         else:
@@ -243,3 +243,11 @@ class FsspecAdapter:
 
 def is_http_url(s: str) -> bool:
     return s.lower().startswith(("http://", "https://"))
+
+
+def filename2key(name: str) -> str:
+    # See `keyFile` and `fileKey` in `Annex/Locations.hs` in the git-annex
+    # source
+    return (
+        name.replace("%", "/").replace("&c", ":").replace("&s", "%").replace("&a", "&")
+    )

--- a/datalad_fuse/fsspec_head.py
+++ b/datalad_fuse/fsspec_head.py
@@ -47,6 +47,11 @@ class FsspecHead(Interface):
             doc="How many bytes to show",
             constraints=EnsureInt() | EnsureNone(),
         ),
+        "mode_transparent": Parameter(
+            args=("--mode-transparent",),
+            action="store_true",
+            doc="Support reading from .git directory",
+        ),
         "path": Parameter(
             args=("path",),
             doc="Path to an annexed file to show the leading contents of",
@@ -62,13 +67,14 @@ class FsspecHead(Interface):
         dataset: Optional[Dataset] = None,
         lines: Optional[int] = None,
         bytes: Optional[int] = None,
+        mode_transparent: bool = False,
     ) -> Iterator[Dict[str, Any]]:
         ds = require_dataset(dataset, purpose="fetch file data", check_installed=True)
         if lines is not None and bytes is not None:
             raise ValueError("'lines' and 'bytes' are mutually exclusive")
         elif lines is None and bytes is None:
             lines = DEFAULT_LINES
-        with FsspecAdapter(ds.path) as fsa:
+        with FsspecAdapter(ds.path, mode_transparent=mode_transparent) as fsa:
             if not os.path.isabs(path):
                 path = os.path.join(ds.path, path)
             with fsa.open(path) as fp:

--- a/datalad_fuse/fuse_.py
+++ b/datalad_fuse/fuse_.py
@@ -225,19 +225,7 @@ class DataLadFUSE(Operations):  # LoggingMixIn,
 
     def readlink(self, path):
         lgr.debug("readlink(path=%r)", path)
-        linked_path = os.readlink(path)
-        # if self._adapter.is_under_annex(path):
-        #     # TODO: we need all leading dirs to exist
-        #     linked_path_full = op.join(op.dirname(path), linked_path)
-        #     linked_path_dir = op.dirname(linked_path_full)
-        #     if not op.exists(linked_path_dir):
-        #         # TODO: this is just a hack - would lack proper permissions etc
-        #         # and probably not needed per se!  We should probably just retain
-        #         # a dict of those we "created" and return the records for them if
-        #         # visited
-        #         lgr.debug("Creating %s", linked_path_dir)
-        #         os.makedirs(linked_path_dir)
-        return linked_path
+        return os.readlink(path)
 
     # ??? seek seems to be not implemented by fusepy/ Operations
 

--- a/datalad_fuse/fuse_.py
+++ b/datalad_fuse/fuse_.py
@@ -103,7 +103,7 @@ class DataLadFUSE(Operations):  # LoggingMixIn,
             lgr.debug("File exists; calling os.stat()")
             r = self._filter_stat(os.stat(path))
         elif op.lexists(path):
-            lgr.debug("Symlink exists? calling os.stat()")
+            lgr.debug("Broken symlink; calling os.lstat()")
             r = self._filter_stat(os.lstat(path))
         else:
             iadok = is_annex_dir_or_key(path)

--- a/datalad_fuse/fuse_.py
+++ b/datalad_fuse/fuse_.py
@@ -4,7 +4,6 @@ import io
 import logging
 import os
 import os.path as op
-from pathlib import Path
 import stat
 from threading import Lock
 import time
@@ -107,11 +106,11 @@ class DataLadFUSE(Operations):  # LoggingMixIn,
         else:
             topdir, dir_or_key = is_annnex_dir_or_key(path)
             if topdir is not None:
-                if dir_or_key == 'key':
+                if dir_or_key == "key":
                     # needs to be open but it is a key. We will let fsspec
                     # to handle it
                     pass
-                elif dir_or_key == 'dir':
+                elif dir_or_key == "dir":
                     # just return that one of the top directory
                     # TODO: cache this since would be a frequent operation
                     r = self._filter_stat(os.stat(topdir))
@@ -124,7 +123,8 @@ class DataLadFUSE(Operations):  # LoggingMixIn,
                 to_close = False
             else:
                 # TODO: it is expensive to open each file just for `getattr`!
-                # We should just fabricate stats from the key here or not even bother???!
+                # We should just fabricate stats from the key here or not even
+                # bother???!
                 lgr.debug("File not already open")
                 fsspec_file = self._adapter.open(path)
                 to_close = True
@@ -339,18 +339,18 @@ def file_getattr(f):
     return data
 
 
-
 # might be called twice in rapid succession for an annex key path
 @lru_cache(maxsize=CACHE_SIZE)
 def is_annnex_dir_or_key(path: str):
-    marker = '.git/annex/'
+    marker = ".git/annex/"
     try:
         idx = path.index(marker)
-        subpath = path[idx + len(marker):]
-        # TODO: .git/annex/objects must exist, but freshly installed one would not have it
-        if subpath.startswith('objects/') and subpath.count('/') == 4:
-            return path[:idx], 'key'
+        subpath = path[idx + len(marker) :]
+        # TODO: .git/annex/objects must exist, but freshly installed one would
+        # not have it
+        if subpath.startswith("objects/") and subpath.count("/") == 4:
+            return path[:idx], "key"
         else:
-            return path[:idx], 'dir'
+            return path[:idx], "dir"
     except ValueError:
         return None, None

--- a/datalad_fuse/tests/test_fuse.py
+++ b/datalad_fuse/tests/test_fuse.py
@@ -17,6 +17,7 @@ def test_fuse(tmp_path, url_dataset):
         sorted(q.name for q in tmp_path.iterdir())
         == [
             ".datalad",
+            ".git",
             ".gitattributes",
         ]
         + sorted(data_files)
@@ -43,6 +44,7 @@ def test_fuse_subdataset(tmp_path, superdataset, cache_clear, tmp_home):
         p.wait(timeout=3)
     assert sorted(q.name for q in tmp_path.iterdir()) == [
         ".datalad",
+        ".git",
         ".gitattributes",
         ".gitmodules",
         "sub",
@@ -51,6 +53,7 @@ def test_fuse_subdataset(tmp_path, superdataset, cache_clear, tmp_home):
         sorted(q.name for q in (tmp_path / "sub").iterdir())
         == [
             ".datalad",
+            ".git",
             ".gitattributes",
         ]
         + sorted(os.path.relpath(fname, "sub") for fname in data_files)

--- a/datalad_fuse/tests/test_fuse.py
+++ b/datalad_fuse/tests/test_fuse.py
@@ -5,23 +5,22 @@ import pytest
 
 
 @pytest.mark.libfuse
-def test_fuse(tmp_path, url_dataset):
+@pytest.mark.parametrize("transparent", [False, True])
+def test_fuse(tmp_path, transparent, url_dataset):
     ds, data_files = url_dataset
+    if transparent:
+        opts = ["--mode-transparent"]
+        dots = [".datalad", ".git", ".gitattributes"]
+    else:
+        opts = []
+        dots = [".datalad", ".gitattributes"]
     p = subprocess.Popen(
-        ["datalad", "fusefs", "-d", ds.path, "--foreground", str(tmp_path)]
+        ["datalad", "fusefs", "-d", ds.path, "--foreground", str(tmp_path), *opts]
     )
     # Check that the command didn't fail immediately:
     with pytest.raises(subprocess.TimeoutExpired):
         p.wait(timeout=3)
-    assert (
-        sorted(q.name for q in tmp_path.iterdir())
-        == [
-            ".datalad",
-            ".git",
-            ".gitattributes",
-        ]
-        + sorted(data_files)
-    )
+    assert sorted(q.name for q in tmp_path.iterdir()) == dots + sorted(data_files)
     for fname, blob in data_files.items():
         assert (tmp_path / fname).read_bytes() == blob
     p.terminate()
@@ -29,34 +28,29 @@ def test_fuse(tmp_path, url_dataset):
 
 @pytest.mark.libfuse
 @pytest.mark.parametrize("cache_clear", [None, "recursive", "visited"])
-def test_fuse_subdataset(tmp_path, superdataset, cache_clear, tmp_home):
+@pytest.mark.parametrize("transparent", [False, True])
+def test_fuse_subdataset(tmp_path, superdataset, cache_clear, transparent, tmp_home):
     if cache_clear is not None:
         with (tmp_home / ".gitconfig").open("a") as fp:
             print("", file=fp)
             print('[datalad "fusefs"]', file=fp)
             print(f"cache-clear = {cache_clear}", file=fp)
     ds, data_files = superdataset
+    if transparent:
+        opts = ["--mode-transparent"]
+        dots = [".datalad", ".git", ".gitattributes"]
+    else:
+        opts = []
+        dots = [".datalad", ".gitattributes"]
     p = subprocess.Popen(
-        ["datalad", "fusefs", "-d", ds.path, "--foreground", str(tmp_path)]
+        ["datalad", "fusefs", "-d", ds.path, "--foreground", str(tmp_path), *opts]
     )
     # Check that the command didn't fail immediately:
     with pytest.raises(subprocess.TimeoutExpired):
         p.wait(timeout=3)
-    assert sorted(q.name for q in tmp_path.iterdir()) == [
-        ".datalad",
-        ".git",
-        ".gitattributes",
-        ".gitmodules",
-        "sub",
-    ]
-    assert (
-        sorted(q.name for q in (tmp_path / "sub").iterdir())
-        == [
-            ".datalad",
-            ".git",
-            ".gitattributes",
-        ]
-        + sorted(os.path.relpath(fname, "sub") for fname in data_files)
+    assert sorted(q.name for q in tmp_path.iterdir()) == dots + [".gitmodules", "sub"]
+    assert sorted(q.name for q in (tmp_path / "sub").iterdir()) == dots + sorted(
+        os.path.relpath(fname, "sub") for fname in data_files
     )
     for fname, blob in data_files.items():
         assert (tmp_path / fname).read_bytes() == blob

--- a/datalad_fuse/tests/test_util.py
+++ b/datalad_fuse/tests/test_util.py
@@ -2,6 +2,7 @@ from typing import Optional, Tuple
 
 import pytest
 
+from datalad_fuse.fsspec import filename2key
 from datalad_fuse.fuse_ import is_annex_dir_or_key
 
 SAMPLE_KEY = "MD5E-s1064--8804d3d11f17e33bd912f1f0947afdb9.json"
@@ -42,3 +43,18 @@ SAMPLE_KEY = "MD5E-s1064--8804d3d11f17e33bd912f1f0947afdb9.json"
 )
 def test_is_annex_dir_or_key(path: str, expected: Optional[Tuple[str, str]]) -> None:
     assert is_annex_dir_or_key(path) == expected
+
+
+@pytest.mark.parametrize(
+    "filename,key",
+    [
+        (
+            "URL--http&c%%127.0.0.1&c35401%text.txt",
+            "URL--http://127.0.0.1:35401/text.txt",
+        ),
+        ("foo&ac", "foo&c"),
+        ("foo&a&s", "foo&%"),
+    ],
+)
+def test_filename2key(filename: str, key: str) -> None:
+    assert filename2key(filename) == key

--- a/datalad_fuse/tests/test_util.py
+++ b/datalad_fuse/tests/test_util.py
@@ -1,0 +1,44 @@
+from typing import Optional, Tuple
+
+import pytest
+
+from datalad_fuse.fuse_ import is_annex_dir_or_key
+
+SAMPLE_KEY = "MD5E-s1064--8804d3d11f17e33bd912f1f0947afdb9.json"
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (f".git/annex/objects/p0/4v/{SAMPLE_KEY}/{SAMPLE_KEY}", (".", "key")),
+        (f".git/annex/objects/p0/4v/{SAMPLE_KEY}/", (".", "dir")),
+        (f".git/annex/objects/p0/4v/{SAMPLE_KEY}", (".", "dir")),
+        (".git/annex/objects/p0/4v", (".", "dir")),
+        (
+            f"some/project/.git/annex/objects/p0/4v/{SAMPLE_KEY}/{SAMPLE_KEY}",
+            ("some/project", "key"),
+        ),
+        ("some/project/.git/annex/objects/p0/4v", ("some/project", "dir")),
+        (
+            f"/usr/src/project/.git/annex/objects/p0/4v/{SAMPLE_KEY}/{SAMPLE_KEY}",
+            ("/usr/src/project", "key"),
+        ),
+        ("/usr/src/project/.git/annex/objects/p0/4v", ("/usr/src/project", "dir")),
+        ("foo.txt", None),
+        ("foo.git/annex/objects/p0/4v", None),
+        ("some/project/.git/refs/heads", None),
+        ("some/project/.git/annex", ("some/project", "dir")),
+        ("some/project/.git/annex/other", ("some/project", "dir")),
+        (
+            "some/project/.git/embedded/sub/.git/annex/objects/p0/4v/"
+            f"{SAMPLE_KEY}/{SAMPLE_KEY}",
+            ("some/project/.git/embedded/sub", "key"),
+        ),
+        (
+            "some/project/.git/embedded/sub/.git/annex/objects/p0/4v",
+            ("some/project/.git/embedded/sub", "dir"),
+        ),
+    ],
+)
+def test_is_annex_dir_or_key(path: str, expected: Optional[Tuple[str, str]]) -> None:
+    assert is_annex_dir_or_key(path) == expected


### PR DESCRIPTION
See https://github.com/datalad/datalad-fuse/issues/45 for more information/motivation. If finalized, closes #45

Notes
- Simplifies get_urls by dropping need for "path". ATM that renders it slower
  since for batch=True on keys needs PR in datalad to be merged and needs fresh
  annex to operate
- Yet to decide either there should be a "mode" switch to be added to switch
  between original (no .git, annexed files are not symlinks) and "transparent".
  I am leaning toward having a mode switch if ends up feasible. Implementation
  wise - might want some subclassing etc.
- Optimization possibly needed to avoid double checks on either path is under
  .git/annex/objects
- FUSE read-write operations to be implemented to allow for   git status
  to work out correctly (ATM barfs)

Ultimate TODO
- verify operation with some datalad metadata extractor (e.g. BIDS) running
  on top of the mounted repo

@jwodder -- feel free to drop this PR completely and redo cleanly.