### PR TITLE
RF: reuse is_annex_dir_or_key  at fsspec level to decide if file is annexed etc

### DIFF
--- a/datalad_fuse/fuse_.py
+++ b/datalad_fuse/fuse_.py
@@ -5,11 +5,9 @@ import logging
 import os
 import os.path as op
 from pathlib import Path
-import re
 import stat
 from threading import Lock
 import time
-from typing import Optional, Tuple
 
 from datalad import cfg
 from datalad.distribution.dataset import Dataset
@@ -21,6 +19,7 @@ from .fsspec import FsspecAdapter
 # Make it relatively small since we are aiming for metadata records ATM
 # Seems of no real good positive net ATM
 # BLOCK_SIZE = 2**20  # 1M. block size to fetch at a time.
+from .utils import is_annex_dir_or_key
 
 lgr = logging.getLogger("datalad.fuse")
 
@@ -332,34 +331,3 @@ def file_getattr(f):
     data["st_ctime"] = time.time()
     data["st_mtime"] = time.time()
     return data
-
-
-# might be called twice in rapid succession for an annex key path
-@lru_cache(maxsize=CACHE_SIZE)
-def is_annex_dir_or_key(path: str) -> Optional[Tuple[str, str]]:
-    parts = list(Path(path).parts)
-    start = 0
-    while True:
-        try:
-            i = parts.index(".git", start)
-        except ValueError:
-            return None
-        if parts[i + 1 : i + 3] == ["annex", "objects"] and all(
-            re.fullmatch(r"[A-Za-z0-9]{2}", p) for p in parts[i + 3 : i + 5]
-        ):
-            topdir = str(Path(*parts[:i]))
-            depth = len(parts) - i
-            if depth <= 5:  # have only two level of hash'ing directories
-                return (topdir, "dir")
-            # matches an annex key regex in the form of
-            # BACKEND[-sSIZE][-mMTIME][-Ssize-Cchunk]--HASH[EXTENSION]
-            if re.fullmatch(
-                r"[A-Z0-9_]{2,14}(?:-s[0-9]+)?(?:-m[0-9]+)?(?:-S[0-9]+-C[0-9]+)?--.*",
-                parts[i + 5],
-            ):
-                # note: key and its directory must match in name
-                if depth == 7 and parts[-1] == parts[-2]:
-                    return (topdir, "key")
-                elif depth == 6:
-                    return (topdir, "dir")
-        start = i + 1

--- a/datalad_fuse/tests/test_util.py
+++ b/datalad_fuse/tests/test_util.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 
 from datalad_fuse.fsspec import filename2key
-from datalad_fuse.fuse_ import is_annex_dir_or_key
+from datalad_fuse.utils import is_annex_dir_or_key
 
 SAMPLE_KEY = "MD5E-s1064--8804d3d11f17e33bd912f1f0947afdb9.json"
 URL_KEY = "URL--http&c%%127.0.0.1&c55485%binary.png"

--- a/datalad_fuse/utils.py
+++ b/datalad_fuse/utils.py
@@ -1,0 +1,37 @@
+from functools import lru_cache
+from pathlib import Path
+import re
+from typing import Optional, Tuple, Union
+
+from datalad_fuse.consts import CACHE_SIZE
+
+
+# might be called twice in rapid succession for an annex key path
+@lru_cache(maxsize=CACHE_SIZE)
+def is_annex_dir_or_key(path: Union[str, Path]) -> Optional[Tuple[str, str]]:
+    parts = list(Path(path).parts)
+    start = 0
+    while True:
+        try:
+            i = parts.index(".git", start)
+        except ValueError:
+            return None
+        if parts[i + 1 : i + 3] == ["annex", "objects"] and all(
+            re.fullmatch(r"[A-Za-z0-9]{2}", p) for p in parts[i + 3 : i + 5]
+        ):
+            topdir = str(Path(*parts[:i]))
+            depth = len(parts) - i
+            if depth <= 5:  # have only two level of hash'ing directories
+                return (topdir, "dir")
+            # matches an annex key regex in the form of
+            # BACKEND[-sSIZE][-mMTIME][-Ssize-Cchunk]--HASH[EXTENSION]
+            if re.fullmatch(
+                r"[A-Z0-9_]{2,14}(?:-s[0-9]+)?(?:-m[0-9]+)?(?:-S[0-9]+-C[0-9]+)?--.*",
+                parts[i + 5],
+            ):
+                # note: key and its directory must match in name
+                if depth == 7 and parts[-1] == parts[-2]:
+                    return (topdir, "key")
+                elif depth == 6:
+                    return (topdir, "dir")
+        start = i + 1


### PR DESCRIPTION
Follow up to #52 .
Since we use lru_cache, should have little impact to "redo the same analysis".  But it is desired since the analysis for either it is an annex key within `fsspec` code was too loose and we ideally should do the same matching for matching a key pattern etc.   A larger RF might be beneficial in the long run.

<details>
<summary>edit: in conjunction with #52 (already merged), this seems to fix my use case of trying with bids extractor for datalad
</summary> 

```shell
(git-annex)lena:/tmp/mnt/openneuro/ds000001[master]
$> time datalad --dbg -f json_pp meta-extract bids sub-04/anat/sub-04_inplaneT2.nii.gz
/home/yoh/proj/datalad/datalad-metalad/venvs/dev3/lib/python3.9/site-packages/bids/variables/entities.py:245: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  self.index = self.index.append(node_row, ignore_index=True)
{                                                                                                                                                                                    
  "action": "meta_extract",
  "metadata_record": {
    "agent_email": "debian@onerussian.com",
    "agent_name": "Yaroslav Halchenko",
    "dataset_id": "7cce28be-8703-11e8-bf98-0242ac120023",
    "dataset_version": "f8e27ac909e50b5b5e311f6be271f0b1757ebb7b",
    "extracted_metadata": {
      "datatype": "anat",
      "extension": ".nii.gz",
      "subject": {
        "age(years)": 20,
        "id": "04",
        "sex": "female"
      },
      "suffix": "inplaneT2"
    },
    "extraction_parameter": {},
    "extraction_time": 1643760149.8911662,
    "extractor_name": "bids",
    "extractor_version": "un-versioned",
    "path": "sub-04/anat/sub-04_inplaneT2.nii.gz",
    "type": "file"
  },
  "path": "/tmp/mnt/openneuro/ds000001/sub-04/anat/sub-04_inplaneT2.nii.gz",
  "status": "ok",
  "type": "file"
}
datalad --dbg -f json_pp meta-extract bids sub-04/anat/sub-04_inplaneT2.nii.g  2.62s user 1.15s system 15% cpu 24.542 total  
```
</details>

attn @jsheunis