### PR TITLE
Assert that `datalad fusefs` test processes terminate quickly

### DIFF
--- a/datalad_fuse/tests/test_fuse.py
+++ b/datalad_fuse/tests/test_fuse.py
@@ -40,6 +40,7 @@ def fusing(
         yield mount_dir
     finally:
         p.terminate()
+        p.wait(timeout=3)
     if wait:
         p.wait()
 


### PR DESCRIPTION
Closes #66.