### PR TITLE
DOC: Set language in Sphinx config to en

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Starting with Sphinx version 5.0, the configuration for the doc's
language should not be None anymore and causes docbuild failures
otherwise (see datalad/datalad#6715). This change sets the language
specification to English (en)