### PR TITLE
Include "data package" in project

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include CHANGELOG.md CONTRIBUTORS LICENSE pyproject.toml tox.ini versioneer.py
 graft _datalad_buildsupport
+graft datalad_fuse
 graft docs
 prune docs/build
 global-exclude *.py[cod]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,11 @@ install_requires =
     datalad >= 0.13.0
     fsspec[fuse,http] >= 2022.1.0
     methodtools ~= 0.4.5
-packages = find:
+packages = find_namespace:
 include_package_data = True
 
 [options.packages.find]
-# do not ship the build helpers
-exclude=
-    _datalad_buildsupport
+include = datalad_fuse*
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This PR causes `datalad_fuse/tests/data/` to be included when datalad-fuse is installed.