### PR TITLE
Update GitHub Actions action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[gh-actions]"
+      include: scope
+    labels:
+      - internal

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,12 +21,12 @@ jobs:
           git config --global user.name "GitHub Almighty"
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
 

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -12,9 +12,9 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up environment
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:  # no need for the history
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.6'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
           chmod a+x ~/auto
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '^3.6'
 

--- a/.github/workflows/test-libfuse.yml
+++ b/.github/workflows/test-libfuse.yml
@@ -21,10 +21,10 @@ jobs:
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.6
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
 
@@ -41,6 +41,6 @@ jobs:
           coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.6
     - name: Install dependencies
@@ -35,6 +35,6 @@ jobs:
         tox -e py3
         coverage xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false


### PR DESCRIPTION
We are currently using older versions of the updated GitHub Actions actions, and these older versions still use Node 12, [which is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

This PR also configures Dependabot to create PRs updating workflows whenever a new version of a used action is released, as discussed in https://github.com/datalad/datalad-extensions/pull/105.