### PR TITLE
Inform also under what dataset path we cannot find a url for a key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^(_datalad_buildsupport/.*|datalad_fuse/_version\.py|versioneer\.py)$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -11,17 +11,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -186,7 +186,9 @@ class DatasetAdapter:
                     lgr.debug(
                         "Failed to open file %s at URL %s: %s", relpath, url, str(e)
                     )
-            raise IOError(f"Could not find a usable URL for {relpath}")
+            raise IOError(
+                f"Could not find a usable URL for {relpath} within {self.path}"
+            )
         else:
             lgr.debug("%s: opening directly", relpath)
             return open(self.path / relpath, mode, **kwargs)  # type: ignore


### PR DESCRIPTION
    
    because otherwise it is hard to impossible to figure out when working on
    a hierarchy of datasets, like now the case in dandisets-healthcheck where we
    observe following errors:
    
            Traceback (most recent call last):
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/fuse.py", line 734, in _wrapper
                    return func(*args, **kwargs) or 0
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/fuse.py", line 834, in open
                    fi.fh = self.operations('open', path.decode(self.encoding),
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/datalad_fuse/fuse_.py", line 75, in __call__
                    return super(DataLadFUSE, self).__call__(op, self.root + path, *args)
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/fuse.py", line 1076, in __call__
                    return getattr(self, op)(*args)
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/datalad_fuse/fuse_.py", line 214, in open
                    fsspec_file = self._adapter.open(path)
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/datalad_fuse/fsspec.py", line 241, in open
                    return dsap.open(relpath, mode=mode, encoding=encoding, errors=errors)
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/datalad_fuse/fsspec.py", line 181, in open
                    raise IOError(f"Could not find a usable URL for {relpath}")
            OSError: Could not find a usable URL for .git/annex/objects/94/qF/SHA256E-s18769644--a2bb2d0d0c5f094aef3eaa68db4087e2944c0372a015180039d98c94573216b5.nwb/SHA256E-s18769644--a2bb2d0d0c5f094aef3eaa68db4087e2944c0372a015180039d98c94573216b5.nwb
    
            During handling of the above exception, another exception occurred:
    
            Traceback (most recent call last):
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/fuse.py", line 737, in _wrapper
                    if e.errno > 0:
            TypeError: '>' not supported between instances of 'NoneType' and 'int'
    
            During handling of the above exception, another exception occurred:
    
            Traceback (most recent call last):
              File "_ctypes/callbacks.c", line 237, in 'calling callback function'
              File "/home/dandi/cronlib/dandisets-healthstatus/venv/lib/python3.8/site-packages/fuse.py", line 756, in _wrapper
                    self.__critical_exception = e
            NameError: name 'self' is not defined
            fuse: bad error value: -659194720
