### PR TITLE
Partial attempt at fixing Benchmark workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 30.3.0", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,9 @@ commands =
 [testenv:benchmark]
 skip_install = True
 deps =
-    asv
-    virtualenv
+    asv[virtualenv]
 commands =
-    asv run --strict {posargs} HEAD^1..HEAD
+    asv run --show-stderr --verbose {posargs} HEAD^1..HEAD
 
 [testenv:typing]
 deps =


### PR DESCRIPTION
It appears that asv 0.6.2 does the wrong thing in regards to fulfilling the `setuptools >= 30.3.0` build requirement in datalad-fuse's `pyproject.toml`; specifically, it installs version 30.3.0 of setuptools — rather than the latest version — in the asv environment, causing the build of methodtools (which requires a higher setuptools) to fail.  Removing the `>= 30.3.0` appears to result in the latest setuptools being installed, but the Benchmark workflow still fails, as it involves testing against the default branch, which still has the `>= 30.3.0` specifier.

I'm thus going to merge this and then create a dummy PR to see if the workflow runs successfully there.