### PR TITLE
Set required git configuration for initiated test repository

### DIFF
--- a/datalad_fuse/tests/test_fsspec_head.py
+++ b/datalad_fuse/tests/test_fsspec_head.py
@@ -131,6 +131,8 @@ def test_git_repo(tmp_path):
     TEXT = (Path(__file__).with_name("data") / "text.txt").read_bytes()
     (tmp_path / "text.txt").write_bytes(TEXT)
     subprocess.run(["git", "add", "text.txt"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "place@holder.org"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Place Holder"], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "Add a file"], cwd=tmp_path, check=True)
     ds = Dataset(tmp_path)
     assert_in_results(


### PR DESCRIPTION
Preventing issues like → https://github.com/datalad/datalad-fuse/issues/112

I really think it would be best to set these configs when initializing the new repo, since this is required by git and tests may run as a sandbox user.