### PR TITLE
ENH: add remfile backend with pluggable backend architecture

### DIFF
--- a/datalad_fuse/__init__.py
+++ b/datalad_fuse/__init__.py
@@ -14,7 +14,7 @@ from datalad.distribution.dataset import (
 )
 from datalad.interface.base import Interface, build_doc, eval_results
 from datalad.interface.results import get_status_dict
-from datalad.support.constraints import EnsureNone
+from datalad.support.constraints import EnsureNone, EnsureStr
 from datalad.support.param import Parameter
 
 from ._version import get_versions
@@ -96,6 +96,16 @@ class FuseFS(Interface):
             default="none",
             doc="Whether to cache fsspec'ed files on disk on not at all",
         ),
+        "backends": Parameter(
+            args=("--backends",),
+            doc=(
+                "Comma-separated list of backends to try for remote file"
+                " access, in priority order.  Available: remfile, fsspec."
+                "  Default: remfile,fsspec (remfile for HDF5 files,"
+                " fsspec for everything else)"
+            ),
+            constraints=EnsureStr() | EnsureNone(),
+        ),
         # TODO: (might better become config vars?)
         # --cache=persist
         # --recursive=follow,get - encountering submodule might install it first
@@ -112,6 +122,7 @@ class FuseFS(Interface):
         mode_transparent: bool = False,
         allow_other: bool = False,
         caching: str | None = None,
+        backends: str | None = None,
     ) -> Iterator[Dict[str, Any]]:
         from fuse import FUSE
 
@@ -133,6 +144,7 @@ class FuseFS(Interface):
                 ds.path,
                 mode_transparent=mode_transparent,
                 caching=caching == "ondisk",
+                backends=backends,
             ),
             mount_path,
             foreground=foreground,

--- a/datalad_fuse/adapter.py
+++ b/datalad_fuse/adapter.py
@@ -1,0 +1,440 @@
+"""Backend-agnostic adapter layer for remote file access."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from enum import Enum
+import json
+import logging
+import os
+import os.path
+from pathlib import Path
+from types import TracebackType
+from typing import IO, Any, Optional, Tuple, cast
+from urllib.parse import urlparse
+import urllib.request
+
+from datalad import cfg
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.utils import get_dataset_root
+import methodtools
+
+from .backends import DEFAULT_BACKENDS, Backend
+from .consts import CACHE_SIZE
+from .fsspec import FsspecBackend
+from .remfile import RemfileBackend
+from .utils import AnnexKey, is_annex_dir_or_key
+
+lgr = logging.getLogger("datalad.fuse.adapter")
+
+FileState = Enum("FileState", "NOT_ANNEXED NO_CONTENT HAS_CONTENT")
+
+
+# ---------------------------------------------------------------------------
+# Backend creation helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_backends(backends: Optional[str] = None) -> tuple[str, bool]:
+    """Resolve backends spec from *backends* argument, config, or default.
+
+    Returns ``(spec, explicit)`` where ``explicit`` is True when the user (or
+    config) supplied the spec and False when falling back to
+    :data:`DEFAULT_BACKENDS`.  Callers use ``explicit`` to decide whether a
+    missing backend is a warning (explicit) or a silent skip (default).
+    """
+    if backends is not None:
+        return backends, True
+    from_cfg = cfg.get("datalad.fusefs.backends", None)
+    if from_cfg is not None:
+        return str(from_cfg), True
+    return DEFAULT_BACKENDS, False
+
+
+def create_backends(
+    spec: str, path: str | Path, caching: bool, explicit: bool = True
+) -> list[Backend]:
+    """Instantiate backends from a comma-separated *spec*.
+
+    Backends that cannot be imported are skipped; missing backends requested
+    via an *explicit* spec (user argument or config) are logged as warnings,
+    while those missing from the default spec are logged at debug level only.
+    Raises ``ValueError`` if no usable backend remains.
+    """
+    backends: list[Backend] = []
+    for name in spec.split(","):
+        name = name.strip()
+        try:
+            if name == "fsspec":
+                backends.append(FsspecBackend(path, caching))
+            elif name == "remfile":
+                backends.append(RemfileBackend())
+            else:
+                raise ValueError(f"Unknown backend: {name!r}")
+        except ImportError as e:
+            if explicit:
+                lgr.warning(
+                    "Backend %r requested but not available (%s); skipping. "
+                    "Install its package or adjust the --backends spec.",
+                    name,
+                    e,
+                )
+            else:
+                lgr.debug("Backend %r not available (not installed), skipping", name)
+    if not backends:
+        raise ValueError(
+            f"No usable backends from spec {spec!r}. "
+            "Install missing packages or adjust --backends / "
+            "datalad.fusefs.backends config."
+        )
+    return backends
+
+
+def is_http_url(s: str) -> bool:
+    return s.lower().startswith(("http://", "https://"))
+
+
+_aneksajo_cache: dict[str, bool] = {}
+
+
+def _is_aneksajo(base_url: str) -> bool:
+    """Check if a URL points to a Forgejo-aneksajo instance.
+
+    Probes ``{scheme}://{host}/api/forgejo/v1/version`` and checks whether
+    the version string contains ``git-annex``, which indicates the
+    forgejo-aneksajo fork.
+
+    Results are cached per ``scheme://host:port`` for the process lifetime.
+    """
+    parsed = urlparse(base_url)
+    # Cache key without userinfo so credentials don't fragment the cache
+    host = parsed.hostname or ""
+    port_suffix = f":{parsed.port}" if parsed.port else ""  # noqa: E231
+    cache_key = f"{parsed.scheme}://{host}{port_suffix}"  # noqa: E231
+
+    if cache_key in _aneksajo_cache:
+        return _aneksajo_cache[cache_key]
+
+    try:
+        api_url = f"{cache_key}/api/forgejo/v1/version"
+        req = urllib.request.Request(api_url, method="GET")
+        req.add_header("Accept", "application/json")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            result = "git-annex" in data.get("version", "")
+    except Exception:
+        lgr.debug("_is_aneksajo(%s) probe failed", cache_key, exc_info=True)
+        result = False
+
+    _aneksajo_cache[cache_key] = result
+    lgr.debug("_is_aneksajo(%s) = %s", cache_key, result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Dataset / Adapter layer
+# ---------------------------------------------------------------------------
+
+
+class DatasetAdapter:
+    def __init__(
+        self,
+        path: str | Path,
+        caching: bool,
+        mode_transparent: bool = False,
+        backends: Optional[str] = None,
+    ) -> None:
+        self.path = Path(path)
+        self.mode_transparent = mode_transparent
+        ds = Dataset(path)
+        self.annex: Optional[AnnexRepo]
+        if isinstance(ds.repo, AnnexRepo):
+            self.annex = ds.repo
+        else:
+            self.annex = None
+        self.commit_dt = datetime.fromtimestamp(
+            ds.repo.get_commit_date(), tz=timezone.utc
+        )
+        spec, explicit = resolve_backends(backends)
+        self._backends = create_backends(spec, path, caching, explicit=explicit)
+
+    def close(self) -> None:
+        if self.annex is not None:
+            self.annex._batched.clear()
+
+    @methodtools.lru_cache(maxsize=CACHE_SIZE)
+    def get_file_state(self, relpath: str) -> tuple[FileState, Optional[AnnexKey]]:
+        p = self.path / relpath
+        lgr.debug("get_file_state: %s", relpath)
+
+        def handle_path_under_annex_objects(
+            p: Path,
+        ) -> tuple[FileState, Optional[AnnexKey]]:
+            iadok = is_annex_dir_or_key(p)
+            if isinstance(iadok, AnnexKey):
+                if p.exists():
+                    return (FileState.HAS_CONTENT, iadok)
+                else:
+                    return (FileState.NO_CONTENT, iadok)
+            else:
+                return (FileState.NOT_ANNEXED, None)
+
+        # Shortcut handling of content under .git, in particular - annex key paths
+        if self.mode_transparent and relpath.startswith(".git/"):
+            return handle_path_under_annex_objects(p)
+
+        # A regular file or git link for which we need to explicitly ask annex about
+        if not p.is_symlink():
+            if p.stat().st_size < 1024 and self.annex is not None:
+                if self.annex.is_under_annex(relpath, batch=True):
+                    key = AnnexKey.parse(self.annex.get_file_key(relpath, batch=True))
+                    if self.annex.file_has_content(relpath, batch=True):
+                        return (FileState.HAS_CONTENT, key)
+                    else:
+                        return (FileState.NO_CONTENT, key)
+            return (FileState.NOT_ANNEXED, None)
+
+        return handle_path_under_annex_objects(
+            Path(os.path.normpath(p.parent / os.readlink(p)))
+        )
+
+    def get_urls(self, key: str) -> Iterator[str]:
+        assert self.annex is not None
+        # TODO: switch to batch=True whenever
+        # https://github.com/datalad/datalad/pull/6379 is merged/released.
+        # Will need a recent git-annex to work!
+        whereis = self.annex.whereis(key, output="full", batch=False, key=True)
+        remote_uuids = []
+        for ru, v in whereis.items():
+            remote_uuids.append(ru)
+            for u in v["urls"]:
+                if is_http_url(u):
+                    yield u
+
+        path_mixed = self.annex._batched.get(
+            "examinekey",
+            annex_options=["--format=annex/objects/${hashdirmixed}${key}/${key}\\n"],
+            path=self.annex.path,
+        )(key)
+        path_lower = self.annex._batched.get(
+            "examinekey",
+            annex_options=["--format=annex/objects/${hashdirlower}${key}/${key}\\n"],
+            path=self.annex.path,
+        )(key)
+
+        uuid2remote_url = {}
+        aneksajo_uuids: set[str] = set()
+        for r in self.annex.get_remotes():
+            if (ru := self.annex.config.get(f"remote.{r}.annex-uuid")) is None:
+                continue
+            if (remote_url := self.annex.config.get(f"remote.{r}.url")) is None:
+                continue
+            remote_url = self.annex.config.rewrite_url(remote_url)
+            uuid2remote_url[ru] = remote_url
+            # Detect Forgejo-aneksajo instances via API probe (cached).
+            # TODO: pushurl could be different from url, should also check
+            #   remote.{r}.pushurl config
+            # TODO: SSH remote URLs not yet supported -- would need to
+            #   derive the HTTP base URL from the SSH URL
+            if is_http_url(remote_url) and _is_aneksajo(remote_url):
+                aneksajo_uuids.add(ru)
+
+        for ru in remote_uuids:
+            try:
+                base_url = uuid2remote_url[ru]
+            except KeyError:
+                continue
+            if is_http_url(base_url):
+                base_stripped = base_url.rstrip("/")
+                # Forgejo/Gitea with aneksajo: use annex/objects endpoint
+                # which supports HEAD and Range requests.
+                # See https://codeberg.org/forgejo-aneksajo/forgejo-aneksajo/issues/111
+                if ru in aneksajo_uuids and base_stripped.endswith(".git"):
+                    forge_base = base_stripped[:-4].rstrip("/")
+                    yield forge_base + "/" + path_lower
+                if base_stripped.lower().endswith("/.git"):
+                    paths = [path_mixed, path_lower]
+                else:
+                    paths = [
+                        path_lower,
+                        path_mixed,
+                        f".git/{path_lower}",
+                        f".git/{path_mixed}",
+                    ]
+                for p in paths:
+                    yield base_stripped + "/" + p
+
+    def open(
+        self,
+        relpath: str,
+        mode: str = "rb",
+        encoding: str = "utf-8",
+        errors: Optional[str] = None,
+    ) -> IO:
+        if mode not in ("r", "rb", "rt"):
+            raise NotImplementedError("Only modes 'r', 'rb', and 'rt' are supported")
+        if mode == "rb":
+            kwargs: dict[str, Any] = {}
+        else:
+            kwargs = {"encoding": encoding, "errors": errors}
+        fstate, key = self.get_file_state(relpath)
+        if fstate is FileState.NOT_ANNEXED:
+            lgr.debug("%s: not under annex", relpath)
+        else:
+            lgr.debug(
+                "%s: under annex, %s content",
+                relpath,
+                "has" if fstate is FileState.HAS_CONTENT else "does not have",
+            )
+        if fstate is FileState.NO_CONTENT:
+            # Walk the backend chain; fall through to next backend on failure
+            last_error: Optional[Exception] = None
+            for backend in self._backends:
+                if not backend.can_handle(key, mode):
+                    lgr.debug(
+                        "%s: backend %s cannot handle (suffix=%s, mode=%s)",
+                        relpath,
+                        backend.name,
+                        key.suffix if key else None,
+                        mode,
+                    )
+                    continue
+                lgr.debug("%s: opening via backend %s", relpath, backend.name)
+                for url in self.get_urls(str(key)):
+                    try:
+                        lgr.debug(
+                            "%s: trying URL %s (backend=%s)",
+                            relpath,
+                            url,
+                            backend.name,
+                        )
+                        return backend.open_url(url, mode, **kwargs)
+                    except FileNotFoundError as e:
+                        lgr.debug(
+                            "Failed to open %s at URL %s: %s",
+                            relpath,
+                            url,
+                            str(e),
+                        )
+                        last_error = e
+                    except Exception as e:
+                        lgr.debug(
+                            "%s: backend %s failed at URL %s: %s",
+                            relpath,
+                            backend.name,
+                            url,
+                            e,
+                        )
+                        last_error = e
+                # All URLs failed for this backend — try the next one
+                lgr.debug(
+                    "%s: backend %s exhausted all URLs, trying next",
+                    relpath,
+                    backend.name,
+                )
+            # No backend succeeded
+            raise IOError(
+                f"Could not open {relpath} within {self.path}"
+                f" (backends={','.join(b.name for b in self._backends)})"
+            ) from last_error
+        else:
+            lgr.debug("%s: opening directly", relpath)
+            return open(self.path / relpath, mode, **kwargs)  # type: ignore[return-value]
+
+    def clear(self) -> None:
+        for backend in self._backends:
+            backend.clear()
+
+
+class RemoteFilesystemAdapter:
+    """Top-level context manager for accessing remote files within a DataLad dataset.
+
+    Resolves paths to their owning dataset, creates per-dataset
+    :class:`DatasetAdapter` instances, and delegates file operations to them.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        caching: bool,
+        mode_transparent: bool = False,
+        backends: Optional[str] = None,
+    ) -> None:
+        self.root = Path(root)
+        self.mode_transparent = mode_transparent
+        self.caching = caching
+        self.backends = backends
+        self.datasets: dict[Path, DatasetAdapter] = {}
+
+    def __enter__(self) -> RemoteFilesystemAdapter:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: Optional[type[BaseException]],
+        _exc_val: Optional[BaseException],
+        _exc_tb: Optional[TracebackType],
+    ) -> None:
+        for ds in self.datasets.values():
+            ds.close()
+        self.datasets.clear()
+
+    @methodtools.lru_cache(maxsize=CACHE_SIZE)
+    # TODO: optimize "caching" more since for all files under the same directory
+    # they all would belong to the same dataset
+    def get_dataset_path(self, path: str | Path) -> Path:
+        path = Path(self.root, path)
+        dspath = get_dataset_root(path)
+        if dspath is None:
+            raise ValueError(f"Path not under DataLad: {path}")
+        dspath = Path(dspath)
+        assert isinstance(dspath, Path)
+        try:
+            dspath.relative_to(self.root)
+        except ValueError:
+            raise ValueError(f"Path not under root dataset: {path}")
+        return dspath
+
+    def resolve_dataset(self, filepath: str | Path) -> tuple[DatasetAdapter, str]:
+        dspath = self.get_dataset_path(filepath)
+        try:
+            dsap = self.datasets[dspath]
+        except KeyError:
+            dsap = self.datasets[dspath] = DatasetAdapter(
+                dspath,
+                mode_transparent=self.mode_transparent,
+                caching=self.caching,
+                backends=self.backends,
+            )
+        relpath = str(Path(filepath).relative_to(dspath))
+        return dsap, relpath
+
+    def open(
+        self,
+        filepath: str | Path,
+        mode: str = "rb",
+        encoding: str = "utf-8",
+        errors: Optional[str] = None,
+    ) -> IO:
+        dsap, relpath = self.resolve_dataset(filepath)
+        lgr.debug(
+            "%s: path resolved to %s in dataset at %s", filepath, relpath, dsap.path
+        )
+        return dsap.open(relpath, mode=mode, encoding=encoding, errors=errors)
+
+    def get_file_state(
+        self, filepath: str | Path
+    ) -> tuple[FileState, Optional[AnnexKey]]:
+        dsap, relpath = self.resolve_dataset(filepath)
+        return cast(Tuple[FileState, Optional[AnnexKey]], dsap.get_file_state(relpath))
+
+    def is_under_annex(self, filepath: str | Path) -> bool:
+        dsap, relpath = self.resolve_dataset(filepath)
+        fstate, _ = dsap.get_file_state(relpath)
+        return fstate is not FileState.NOT_ANNEXED
+
+    def get_commit_datetime(self, filepath: str | Path) -> datetime:
+        dsap, _ = self.resolve_dataset(filepath)
+        return dsap.commit_dt

--- a/datalad_fuse/adapter.py
+++ b/datalad_fuse/adapter.py
@@ -1,0 +1,387 @@
+"""Backend-agnostic adapter layer for remote file access."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from enum import Enum
+import logging
+import os
+import os.path
+from pathlib import Path
+from types import TracebackType
+from typing import IO, Any, Optional, Tuple, cast
+
+from datalad import cfg
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad.utils import get_dataset_root
+import methodtools
+
+from .backends import DEFAULT_BACKENDS, Backend
+from .consts import CACHE_SIZE
+from .fsspec import FsspecBackend
+from .remfile import RemfileBackend
+from .utils import AnnexKey, is_annex_dir_or_key
+
+lgr = logging.getLogger("datalad.fuse.adapter")
+
+FileState = Enum("FileState", "NOT_ANNEXED NO_CONTENT HAS_CONTENT")
+
+
+# ---------------------------------------------------------------------------
+# Backend creation helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_backends(backends: Optional[str] = None) -> tuple[str, bool]:
+    """Resolve backends spec from *backends* argument, config, or default.
+
+    Returns ``(spec, explicit)`` where ``explicit`` is True when the user (or
+    config) supplied the spec and False when falling back to
+    :data:`DEFAULT_BACKENDS`.  Callers use ``explicit`` to decide whether a
+    missing backend is a warning (explicit) or a silent skip (default).
+    """
+    if backends is not None:
+        return backends, True
+    from_cfg = cfg.get("datalad.fusefs.backends", None)
+    if from_cfg is not None:
+        return str(from_cfg), True
+    return DEFAULT_BACKENDS, False
+
+
+def create_backends(
+    spec: str, path: str | Path, caching: bool, explicit: bool = True
+) -> list[Backend]:
+    """Instantiate backends from a comma-separated *spec*.
+
+    Backends that cannot be imported are skipped; missing backends requested
+    via an *explicit* spec (user argument or config) are logged as warnings,
+    while those missing from the default spec are logged at debug level only.
+    Raises ``ValueError`` if no usable backend remains.
+    """
+    backends: list[Backend] = []
+    for name in spec.split(","):
+        name = name.strip()
+        try:
+            if name == "fsspec":
+                backends.append(FsspecBackend(path, caching))
+            elif name == "remfile":
+                backends.append(RemfileBackend())
+            else:
+                raise ValueError(f"Unknown backend: {name!r}")
+        except ImportError as e:
+            if explicit:
+                lgr.warning(
+                    "Backend %r requested but not available (%s); skipping. "
+                    "Install its package or adjust the --backends spec.",
+                    name,
+                    e,
+                )
+            else:
+                lgr.debug("Backend %r not available (not installed), skipping", name)
+    if not backends:
+        raise ValueError(
+            f"No usable backends from spec {spec!r}. "
+            "Install missing packages or adjust --backends / "
+            "datalad.fusefs.backends config."
+        )
+    return backends
+
+
+def is_http_url(s: str) -> bool:
+    return s.lower().startswith(("http://", "https://"))
+
+
+# ---------------------------------------------------------------------------
+# Dataset / Adapter layer
+# ---------------------------------------------------------------------------
+
+
+class DatasetAdapter:
+    def __init__(
+        self,
+        path: str | Path,
+        caching: bool,
+        mode_transparent: bool = False,
+        backends: Optional[str] = None,
+    ) -> None:
+        self.path = Path(path)
+        self.mode_transparent = mode_transparent
+        ds = Dataset(path)
+        self.annex: Optional[AnnexRepo]
+        if isinstance(ds.repo, AnnexRepo):
+            self.annex = ds.repo
+        else:
+            self.annex = None
+        self.commit_dt = datetime.fromtimestamp(
+            ds.repo.get_commit_date(), tz=timezone.utc
+        )
+        spec, explicit = resolve_backends(backends)
+        self._backends = create_backends(spec, path, caching, explicit=explicit)
+
+    def close(self) -> None:
+        if self.annex is not None:
+            self.annex._batched.clear()
+
+    @methodtools.lru_cache(maxsize=CACHE_SIZE)
+    def get_file_state(self, relpath: str) -> tuple[FileState, Optional[AnnexKey]]:
+        p = self.path / relpath
+        lgr.debug("get_file_state: %s", relpath)
+
+        def handle_path_under_annex_objects(
+            p: Path,
+        ) -> tuple[FileState, Optional[AnnexKey]]:
+            iadok = is_annex_dir_or_key(p)
+            if isinstance(iadok, AnnexKey):
+                if p.exists():
+                    return (FileState.HAS_CONTENT, iadok)
+                else:
+                    return (FileState.NO_CONTENT, iadok)
+            else:
+                return (FileState.NOT_ANNEXED, None)
+
+        # Shortcut handling of content under .git, in particular - annex key paths
+        if self.mode_transparent and relpath.startswith(".git/"):
+            return handle_path_under_annex_objects(p)
+
+        # A regular file or git link for which we need to explicitly ask annex about
+        if not p.is_symlink():
+            if p.stat().st_size < 1024 and self.annex is not None:
+                if self.annex.is_under_annex(relpath, batch=True):
+                    key = AnnexKey.parse(self.annex.get_file_key(relpath, batch=True))
+                    if self.annex.file_has_content(relpath, batch=True):
+                        return (FileState.HAS_CONTENT, key)
+                    else:
+                        return (FileState.NO_CONTENT, key)
+            return (FileState.NOT_ANNEXED, None)
+
+        return handle_path_under_annex_objects(
+            Path(os.path.normpath(p.parent / os.readlink(p)))
+        )
+
+    def get_urls(self, key: str) -> Iterator[str]:
+        assert self.annex is not None
+        # TODO: switch to batch=True whenever
+        # https://github.com/datalad/datalad/pull/6379 is merged/released.
+        # Will need a recent git-annex to work!
+        whereis = self.annex.whereis(key, output="full", batch=False, key=True)
+        remote_uuids = []
+        for ru, v in whereis.items():
+            remote_uuids.append(ru)
+            for u in v["urls"]:
+                if is_http_url(u):
+                    yield u
+
+        path_mixed = self.annex._batched.get(
+            "examinekey",
+            annex_options=["--format=annex/objects/${hashdirmixed}${key}/${key}\\n"],
+            path=self.annex.path,
+        )(key)
+        path_lower = self.annex._batched.get(
+            "examinekey",
+            annex_options=["--format=annex/objects/${hashdirlower}${key}/${key}\\n"],
+            path=self.annex.path,
+        )(key)
+
+        uuid2remote_url = {}
+        for r in self.annex.get_remotes():
+            ru = self.annex.config.get(f"remote.{r}.annex-uuid")
+            if ru is None:
+                continue
+            remote_url = self.annex.config.get(f"remote.{r}.url")
+            if remote_url is None:
+                continue
+            remote_url = self.annex.config.rewrite_url(remote_url)
+            uuid2remote_url[ru] = remote_url
+
+        for ru in remote_uuids:
+            try:
+                base_url = uuid2remote_url[ru]
+            except KeyError:
+                continue
+            if is_http_url(base_url):
+                if base_url.lower().rstrip("/").endswith("/.git"):
+                    paths = [path_mixed, path_lower]
+                else:
+                    paths = [
+                        path_lower,
+                        path_mixed,
+                        f".git/{path_lower}",
+                        f".git/{path_mixed}",
+                    ]
+                for p in paths:
+                    yield base_url.rstrip("/") + "/" + p
+
+    def open(
+        self,
+        relpath: str,
+        mode: str = "rb",
+        encoding: str = "utf-8",
+        errors: Optional[str] = None,
+    ) -> IO:
+        if mode not in ("r", "rb", "rt"):
+            raise NotImplementedError("Only modes 'r', 'rb', and 'rt' are supported")
+        if mode == "rb":
+            kwargs: dict[str, Any] = {}
+        else:
+            kwargs = {"encoding": encoding, "errors": errors}
+        fstate, key = self.get_file_state(relpath)
+        if fstate is FileState.NOT_ANNEXED:
+            lgr.debug("%s: not under annex", relpath)
+        else:
+            lgr.debug(
+                "%s: under annex, %s content",
+                relpath,
+                "has" if fstate is FileState.HAS_CONTENT else "does not have",
+            )
+        if fstate is FileState.NO_CONTENT:
+            # Walk the backend chain; fall through to next backend on failure
+            last_error: Optional[Exception] = None
+            for backend in self._backends:
+                if not backend.can_handle(key, mode):
+                    lgr.debug(
+                        "%s: backend %s cannot handle (suffix=%s, mode=%s)",
+                        relpath,
+                        backend.name,
+                        key.suffix if key else None,
+                        mode,
+                    )
+                    continue
+                lgr.debug("%s: opening via backend %s", relpath, backend.name)
+                for url in self.get_urls(str(key)):
+                    try:
+                        lgr.debug(
+                            "%s: trying URL %s (backend=%s)",
+                            relpath,
+                            url,
+                            backend.name,
+                        )
+                        return backend.open_url(url, mode, **kwargs)
+                    except FileNotFoundError as e:
+                        lgr.debug(
+                            "Failed to open %s at URL %s: %s",
+                            relpath,
+                            url,
+                            str(e),
+                        )
+                        last_error = e
+                    except Exception as e:
+                        lgr.debug(
+                            "%s: backend %s failed at URL %s: %s",
+                            relpath,
+                            backend.name,
+                            url,
+                            e,
+                        )
+                        last_error = e
+                # All URLs failed for this backend — try the next one
+                lgr.debug(
+                    "%s: backend %s exhausted all URLs, trying next",
+                    relpath,
+                    backend.name,
+                )
+            # No backend succeeded
+            raise IOError(
+                f"Could not open {relpath} within {self.path}"
+                f" (backends={','.join(b.name for b in self._backends)})"
+            ) from last_error
+        else:
+            lgr.debug("%s: opening directly", relpath)
+            return open(self.path / relpath, mode, **kwargs)  # type: ignore[return-value]
+
+    def clear(self) -> None:
+        for backend in self._backends:
+            backend.clear()
+
+
+class RemoteFilesystemAdapter:
+    """Top-level context manager for accessing remote files within a DataLad dataset.
+
+    Resolves paths to their owning dataset, creates per-dataset
+    :class:`DatasetAdapter` instances, and delegates file operations to them.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        caching: bool,
+        mode_transparent: bool = False,
+        backends: Optional[str] = None,
+    ) -> None:
+        self.root = Path(root)
+        self.mode_transparent = mode_transparent
+        self.caching = caching
+        self.backends = backends
+        self.datasets: dict[Path, DatasetAdapter] = {}
+
+    def __enter__(self) -> RemoteFilesystemAdapter:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: Optional[type[BaseException]],
+        _exc_val: Optional[BaseException],
+        _exc_tb: Optional[TracebackType],
+    ) -> None:
+        for ds in self.datasets.values():
+            ds.close()
+        self.datasets.clear()
+
+    @methodtools.lru_cache(maxsize=CACHE_SIZE)
+    # TODO: optimize "caching" more since for all files under the same directory
+    # they all would belong to the same dataset
+    def get_dataset_path(self, path: str | Path) -> Path:
+        path = Path(self.root, path)
+        dspath = get_dataset_root(path)
+        if dspath is None:
+            raise ValueError(f"Path not under DataLad: {path}")
+        dspath = Path(dspath)
+        assert isinstance(dspath, Path)
+        try:
+            dspath.relative_to(self.root)
+        except ValueError:
+            raise ValueError(f"Path not under root dataset: {path}")
+        return dspath
+
+    def resolve_dataset(self, filepath: str | Path) -> tuple[DatasetAdapter, str]:
+        dspath = self.get_dataset_path(filepath)
+        try:
+            dsap = self.datasets[dspath]
+        except KeyError:
+            dsap = self.datasets[dspath] = DatasetAdapter(
+                dspath,
+                mode_transparent=self.mode_transparent,
+                caching=self.caching,
+                backends=self.backends,
+            )
+        relpath = str(Path(filepath).relative_to(dspath))
+        return dsap, relpath
+
+    def open(
+        self,
+        filepath: str | Path,
+        mode: str = "rb",
+        encoding: str = "utf-8",
+        errors: Optional[str] = None,
+    ) -> IO:
+        dsap, relpath = self.resolve_dataset(filepath)
+        lgr.debug(
+            "%s: path resolved to %s in dataset at %s", filepath, relpath, dsap.path
+        )
+        return dsap.open(relpath, mode=mode, encoding=encoding, errors=errors)
+
+    def get_file_state(
+        self, filepath: str | Path
+    ) -> tuple[FileState, Optional[AnnexKey]]:
+        dsap, relpath = self.resolve_dataset(filepath)
+        return cast(Tuple[FileState, Optional[AnnexKey]], dsap.get_file_state(relpath))
+
+    def is_under_annex(self, filepath: str | Path) -> bool:
+        dsap, relpath = self.resolve_dataset(filepath)
+        fstate, _ = dsap.get_file_state(relpath)
+        return fstate is not FileState.NOT_ANNEXED
+
+    def get_commit_datetime(self, filepath: str | Path) -> datetime:
+        dsap, _ = self.resolve_dataset(filepath)
+        return dsap.commit_dt

--- a/datalad_fuse/adapter.py
+++ b/datalad_fuse/adapter.py
@@ -66,6 +66,9 @@ def create_backends(
     backends: list[Backend] = []
     for name in spec.split(","):
         name = name.strip()
+        if not name:
+            # tolerate stray commas / whitespace, e.g. "remfile,,fsspec"
+            continue
         try:
             if name == "fsspec":
                 backends.append(FsspecBackend(path, caching))

--- a/datalad_fuse/backends.py
+++ b/datalad_fuse/backends.py
@@ -1,0 +1,27 @@
+"""Abstract base for remote file access backends and shared constants."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import IO, Any, Optional
+
+from .utils import AnnexKey
+
+DEFAULT_BACKENDS = "remfile,fsspec"
+
+
+class Backend(ABC):
+    """Base class for remote file access backends."""
+
+    name: str
+
+    @abstractmethod
+    def can_handle(self, key: Optional[AnnexKey], mode: str) -> bool:
+        """Return True if this backend should be used for *key* in *mode*."""
+
+    @abstractmethod
+    def open_url(self, url: str, mode: str = "rb", **kwargs: Any) -> IO:
+        """Open *url* and return a file-like object."""
+
+    def clear(self) -> None:  # noqa: B027
+        """Clear any caches held by this backend.  Default: no-op."""

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -1,345 +1,69 @@
+"""FsspecBackend — remote file access via fsspec's HTTPFileSystem.
+
+This module also provides backward-compatible imports for names that have
+moved to :mod:`datalad_fuse.backends`, :mod:`datalad_fuse.remfile`, and
+:mod:`datalad_fuse.adapter` as part of the multi-backend refactoring.
+Importing those names from here still works but emits a
+:class:`DeprecationWarning`.
+"""
+
 from __future__ import annotations
 
-from collections.abc import Iterator
-from datetime import datetime, timezone
-from enum import Enum
-import json
+import importlib
 import logging
 import os
-import os.path
 from pathlib import Path
-from types import SimpleNamespace, TracebackType
-from typing import IO, Any, Optional, Tuple, cast
-from urllib.parse import urlparse
-import urllib.request
+from types import SimpleNamespace
+from typing import IO, Any, Optional
+import warnings
 
 import aiohttp
 from aiohttp_retry import ListRetry, RetryClient
-from datalad.distribution.dataset import Dataset
-from datalad.support.annexrepo import AnnexRepo
-from datalad.utils import get_dataset_root
 from fsspec.exceptions import BlocksizeMismatchError
 from fsspec.implementations.cached import CachingFileSystem
 from fsspec.implementations.http import HTTPFileSystem
-import methodtools
 
-from .consts import CACHE_SIZE
-from .utils import AnnexKey, is_annex_dir_or_key
+from .backends import Backend as _Backend
+from .utils import AnnexKey
 
 lgr = logging.getLogger("datalad.fuse.fsspec")
 
-FileState = Enum("FileState", "NOT_ANNEXED NO_CONTENT HAS_CONTENT")
 
+class FsspecBackend(_Backend):
+    """Backend using fsspec's HTTPFileSystem (optionally with disk caching)."""
 
-class DatasetAdapter:
-    def __init__(
-        self, path: str | Path, caching: bool, mode_transparent: bool = False
-    ) -> None:
-        self.path = Path(path)
-        self.mode_transparent = mode_transparent
-        ds = Dataset(path)
-        self.annex: Optional[AnnexRepo]
-        if isinstance(ds.repo, AnnexRepo):
-            self.annex = ds.repo
-        else:
-            self.annex = None
-        self.commit_dt = datetime.fromtimestamp(
-            ds.repo.get_commit_date(), tz=timezone.utc
-        )
-        self.caching = caching
+    name = "fsspec"
+
+    def __init__(self, path: str | Path, caching: bool) -> None:
         fs = HTTPFileSystem(get_client=get_client)
-        if self.caching:
-            self.fs = CachingFileSystem(
+        if caching:
+            self.fs: HTTPFileSystem | CachingFileSystem = CachingFileSystem(
                 fs=fs,
-                # target_protocol='blockcache',
                 cache_storage=os.path.join(path, ".git", "datalad", "cache", "fsspec"),
-                # cache_check=600,
-                # block_size=1024,
-                # check_files=True,
-                # expiry_times=True,
-                # same_names=True
             )
         else:
             self.fs = fs
+        self._caching = caching
 
-    def close(self) -> None:
-        if self.annex is not None:
-            self.annex._batched.clear()
+    def can_handle(self, key: Optional[AnnexKey], mode: str) -> bool:  # noqa: U100
+        return True  # fsspec handles everything
 
-    @methodtools.lru_cache(maxsize=CACHE_SIZE)
-    def get_file_state(self, relpath: str) -> tuple[FileState, Optional[AnnexKey]]:
-        p = self.path / relpath
-        lgr.debug("get_file_state: %s", relpath)
-
-        def handle_path_under_annex_objects(
-            p: Path,
-        ) -> tuple[FileState, Optional[AnnexKey]]:
-            iadok = is_annex_dir_or_key(p)
-            if isinstance(iadok, AnnexKey):
-                if p.exists():
-                    return (FileState.HAS_CONTENT, iadok)
-                else:
-                    return (FileState.NO_CONTENT, iadok)
-            else:
-                return (FileState.NOT_ANNEXED, None)
-
-        # Shortcut handling of content under .git, in particular - annex key paths
-        if self.mode_transparent and relpath.startswith(".git/"):
-            return handle_path_under_annex_objects(p)
-
-        # A regular file or git link for which we need to explicitly ask annex about
-        if not p.is_symlink():
-            if p.stat().st_size < 1024 and self.annex is not None:
-                if self.annex.is_under_annex(relpath, batch=True):
-                    key = AnnexKey.parse(self.annex.get_file_key(relpath, batch=True))
-                    if self.annex.file_has_content(relpath, batch=True):
-                        return (FileState.HAS_CONTENT, key)
-                    else:
-                        return (FileState.NO_CONTENT, key)
-            return (FileState.NOT_ANNEXED, None)
-
-        return handle_path_under_annex_objects(
-            Path(os.path.normpath(p.parent / os.readlink(p)))
-        )
-
-    def get_urls(self, key: str) -> Iterator[str]:
-        assert self.annex is not None
-        # TODO: switch to batch=True whenever
-        # https://github.com/datalad/datalad/pull/6379 is merged/released.
-        # Will need a recent git-annex to work!
-        whereis = self.annex.whereis(key, output="full", batch=False, key=True)
-        remote_uuids = []
-        for ru, v in whereis.items():
-            remote_uuids.append(ru)
-            for u in v["urls"]:
-                if is_http_url(u):
-                    yield u
-
-        path_mixed = self.annex._batched.get(
-            "examinekey",
-            annex_options=["--format=annex/objects/${hashdirmixed}${key}/${key}\\n"],
-            path=self.annex.path,
-        )(key)
-        path_lower = self.annex._batched.get(
-            "examinekey",
-            annex_options=["--format=annex/objects/${hashdirlower}${key}/${key}\\n"],
-            path=self.annex.path,
-        )(key)
-
-        uuid2remote_url = {}
-        aneksajo_uuids: set[str] = set()
-        for r in self.annex.get_remotes():
-            if (ru := self.annex.config.get(f"remote.{r}.annex-uuid")) is None:
-                continue
-            if (remote_url := self.annex.config.get(f"remote.{r}.url")) is None:
-                continue
-            remote_url = self.annex.config.rewrite_url(remote_url)
-            uuid2remote_url[ru] = remote_url
-            # Detect Forgejo-aneksajo instances via API probe (cached).
-            # TODO: pushurl could be different from url, should also check
-            #   remote.{r}.pushurl config
-            # TODO: SSH remote URLs not yet supported -- would need to
-            #   derive the HTTP base URL from the SSH URL
-            if is_http_url(remote_url) and _is_aneksajo(remote_url):
-                aneksajo_uuids.add(ru)
-
-        for ru in remote_uuids:
-            try:
-                base_url = uuid2remote_url[ru]
-            except KeyError:
-                continue
-            if is_http_url(base_url):
-                base_stripped = base_url.rstrip("/")
-                # Forgejo/Gitea with aneksajo: use annex/objects endpoint
-                # which supports HEAD and Range requests.
-                # See https://codeberg.org/forgejo-aneksajo/forgejo-aneksajo/issues/111
-                if ru in aneksajo_uuids and base_stripped.endswith(".git"):
-                    forge_base = base_stripped[:-4].rstrip("/")
-                    yield forge_base + "/" + path_lower
-                if base_stripped.lower().endswith("/.git"):
-                    paths = [path_mixed, path_lower]
-                else:
-                    paths = [
-                        path_lower,
-                        path_mixed,
-                        f".git/{path_lower}",
-                        f".git/{path_mixed}",
-                    ]
-                for p in paths:
-                    yield base_stripped + "/" + p
-
-    def open(
-        self,
-        relpath: str,
-        mode: str = "rb",
-        encoding: str = "utf-8",
-        errors: Optional[str] = None,
-    ) -> IO:
-        if mode not in ("r", "rb", "rt"):
-            raise NotImplementedError("Only modes 'r', 'rb', and 'rt' are supported")
-        if mode == "rb":
-            kwargs = {}
-        else:
-            kwargs = {"encoding": encoding, "errors": errors}
-        fstate, key = self.get_file_state(relpath)
-        if fstate is FileState.NOT_ANNEXED:
-            lgr.debug("%s: not under annex", relpath)
-        else:
-            lgr.debug(
-                "%s: under annex, %s content",
-                relpath,
-                "has" if fstate is FileState.HAS_CONTENT else "does not have",
+    def open_url(self, url: str, mode: str = "rb", **kwargs: Any) -> IO:
+        try:
+            return self.fs.open(url, mode, **kwargs)  # type: ignore[no-any-return]
+        except BlocksizeMismatchError as e:
+            lgr.warning(
+                "Blocksize mismatch for %s: %s; clearing cache and retrying", url, e
             )
-        if fstate is FileState.NO_CONTENT:
-            lgr.debug("%s: opening via fsspec", relpath)
-            for url in self.get_urls(str(key)):
-                try:
-                    lgr.debug("%s: Attempting to open via URL %s", relpath, url)
-                    return self.fs.open(url, mode, **kwargs)  # type: ignore
-                except BlocksizeMismatchError as e:
-                    lgr.warning(
-                        "%s: Blocksize mismatch: %s; deleting cached file and"
-                        " re-opening",
-                        relpath,
-                        e,
-                    )
-                    self.fs.pop_from_cache(url)
-                    return self.fs.open(url, mode, **kwargs)  # type: ignore
-                except FileNotFoundError as e:
-                    lgr.debug(
-                        "Failed to open file %s at URL %s: %s", relpath, url, str(e)
-                    )
-            raise IOError(
-                f"Could not find a usable URL for {relpath} within {self.path}"
-            )
-        else:
-            lgr.debug("%s: opening directly", relpath)
-            return open(self.path / relpath, mode, **kwargs)  # type: ignore
+            self.fs.pop_from_cache(url)
+            return self.fs.open(url, mode, **kwargs)  # type: ignore[no-any-return]
 
     def clear(self) -> None:
-        if self.caching:
+        if self._caching:
             self.fs.clear_cache()
 
 
-class FsspecAdapter:
-    def __init__(
-        self, root: str | Path, caching: bool, mode_transparent: bool = False
-    ) -> None:
-        self.root = Path(root)
-        self.mode_transparent = mode_transparent
-        self.caching = caching
-        self.datasets: dict[Path, DatasetAdapter] = {}
-
-    def __enter__(self) -> FsspecAdapter:
-        return self
-
-    def __exit__(
-        self,
-        _exc_type: Optional[type[BaseException]],
-        _exc_val: Optional[BaseException],
-        _exc_tb: Optional[TracebackType],
-    ) -> None:
-        for ds in self.datasets.values():
-            ds.close()
-        self.datasets.clear()
-
-    @methodtools.lru_cache(maxsize=CACHE_SIZE)
-    # TODO: optimize "caching" more since for all files under the same directory
-    # they all would belong to the same dataset
-    def get_dataset_path(self, path: str | Path) -> Path:
-        path = Path(self.root, path)
-        dspath = get_dataset_root(path)
-        if dspath is None:
-            raise ValueError(f"Path not under DataLad: {path}")
-        dspath = Path(dspath)
-        assert isinstance(dspath, Path)
-        try:
-            dspath.relative_to(self.root)
-        except ValueError:
-            raise ValueError(f"Path not under root dataset: {path}")
-        return dspath
-
-    def resolve_dataset(self, filepath: str | Path) -> tuple[DatasetAdapter, str]:
-        dspath = self.get_dataset_path(filepath)
-        try:
-            dsap = self.datasets[dspath]
-        except KeyError:
-            dsap = self.datasets[dspath] = DatasetAdapter(
-                dspath,
-                mode_transparent=self.mode_transparent,
-                caching=self.caching,
-            )
-        relpath = str(Path(filepath).relative_to(dspath))
-        return dsap, relpath
-
-    def open(
-        self,
-        filepath: str | Path,
-        mode: str = "rb",
-        encoding: str = "utf-8",
-        errors: Optional[str] = None,
-    ) -> IO:
-        dsap, relpath = self.resolve_dataset(filepath)
-        lgr.debug(
-            "%s: path resolved to %s in dataset at %s", filepath, relpath, dsap.path
-        )
-        return dsap.open(relpath, mode=mode, encoding=encoding, errors=errors)
-
-    def get_file_state(
-        self, filepath: str | Path
-    ) -> tuple[FileState, Optional[AnnexKey]]:
-        dsap, relpath = self.resolve_dataset(filepath)
-        return cast(Tuple[FileState, Optional[AnnexKey]], dsap.get_file_state(relpath))
-
-    def is_under_annex(self, filepath: str | Path) -> bool:
-        dsap, relpath = self.resolve_dataset(filepath)
-        fstate, _ = dsap.get_file_state(relpath)
-        return fstate is not FileState.NOT_ANNEXED
-
-    def get_commit_datetime(self, filepath: str | Path) -> datetime:
-        dsap, _ = self.resolve_dataset(filepath)
-        return dsap.commit_dt
-
-
-def is_http_url(s: str) -> bool:
-    return s.lower().startswith(("http://", "https://"))
-
-
-_aneksajo_cache: dict[str, bool] = {}
-
-
-def _is_aneksajo(base_url: str) -> bool:
-    """Check if a URL points to a Forgejo-aneksajo instance.
-
-    Probes ``{scheme}://{host}/api/forgejo/v1/version`` and checks whether
-    the version string contains ``git-annex``, which indicates the
-    forgejo-aneksajo fork.
-
-    Results are cached per ``scheme://host:port`` for the process lifetime.
-    """
-    parsed = urlparse(base_url)
-    # Cache key without userinfo so credentials don't fragment the cache
-    host = parsed.hostname or ""
-    port_suffix = f":{parsed.port}" if parsed.port else ""  # noqa: E231
-    cache_key = f"{parsed.scheme}://{host}{port_suffix}"  # noqa: E231
-
-    if cache_key in _aneksajo_cache:
-        return _aneksajo_cache[cache_key]
-
-    try:
-        api_url = f"{cache_key}/api/forgejo/v1/version"
-        req = urllib.request.Request(api_url, method="GET")
-        req.add_header("Accept", "application/json")
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read().decode())
-            result = "git-annex" in data.get("version", "")
-    except Exception:
-        lgr.debug("_is_aneksajo(%s) probe failed", cache_key, exc_info=True)
-        result = False
-
-    _aneksajo_cache[cache_key] = result
-    lgr.debug("_is_aneksajo(%s) = %s", cache_key, result)
-    return result
+# -- Async HTTP helpers (fsspec-specific) ------------------------------------
 
 
 async def on_request_start(
@@ -361,3 +85,30 @@ async def get_client(**kwargs: Any) -> RetryClient:
         ),
         retry_options=ListRetry(timeouts=[1, 2, 6, 15, 36]),
     )
+
+
+# -- Backward compatibility --------------------------------------------------
+
+_COMPAT_MAP: dict[str, tuple[str, str]] = {
+    # Only names that existed in the pre-refactoring fsspec.py
+    # name -> (module, canonical_name)
+    "FsspecAdapter": ("datalad_fuse.adapter", "RemoteFilesystemAdapter"),
+    "DatasetAdapter": ("datalad_fuse.adapter", "DatasetAdapter"),
+    "FileState": ("datalad_fuse.adapter", "FileState"),
+    "is_http_url": ("datalad_fuse.adapter", "is_http_url"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _COMPAT_MAP:
+        module_path, canonical_name = _COMPAT_MAP[name]
+        mod = importlib.import_module(module_path)
+        obj = getattr(mod, canonical_name)
+        warnings.warn(
+            f"Importing {name!r} from 'datalad_fuse.fsspec' is deprecated. "
+            f"Use 'from {module_path} import {canonical_name}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return obj
+    raise AttributeError(f"module 'datalad_fuse.fsspec' has no attribute {name!r}")

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -1,292 +1,69 @@
+"""FsspecBackend — remote file access via fsspec's HTTPFileSystem.
+
+This module also provides backward-compatible imports for names that have
+moved to :mod:`datalad_fuse.backends`, :mod:`datalad_fuse.remfile`, and
+:mod:`datalad_fuse.adapter` as part of the multi-backend refactoring.
+Importing those names from here still works but emits a
+:class:`DeprecationWarning`.
+"""
+
 from __future__ import annotations
 
-from collections.abc import Iterator
-from datetime import datetime, timezone
-from enum import Enum
+import importlib
 import logging
 import os
-import os.path
 from pathlib import Path
-from types import SimpleNamespace, TracebackType
-from typing import IO, Any, Optional, Tuple, cast
+from types import SimpleNamespace
+from typing import IO, Any, Optional
+import warnings
 
 import aiohttp
 from aiohttp_retry import ListRetry, RetryClient
-from datalad.distribution.dataset import Dataset
-from datalad.support.annexrepo import AnnexRepo
-from datalad.utils import get_dataset_root
 from fsspec.exceptions import BlocksizeMismatchError
 from fsspec.implementations.cached import CachingFileSystem
 from fsspec.implementations.http import HTTPFileSystem
-import methodtools
 
-from .consts import CACHE_SIZE
-from .utils import AnnexKey, is_annex_dir_or_key
+from .backends import Backend as _Backend
+from .utils import AnnexKey
 
 lgr = logging.getLogger("datalad.fuse.fsspec")
 
-FileState = Enum("FileState", "NOT_ANNEXED NO_CONTENT HAS_CONTENT")
 
+class FsspecBackend(_Backend):
+    """Backend using fsspec's HTTPFileSystem (optionally with disk caching)."""
 
-class DatasetAdapter:
-    def __init__(
-        self, path: str | Path, caching: bool, mode_transparent: bool = False
-    ) -> None:
-        self.path = Path(path)
-        self.mode_transparent = mode_transparent
-        ds = Dataset(path)
-        self.annex: Optional[AnnexRepo]
-        if isinstance(ds.repo, AnnexRepo):
-            self.annex = ds.repo
-        else:
-            self.annex = None
-        self.commit_dt = datetime.fromtimestamp(
-            ds.repo.get_commit_date(), tz=timezone.utc
-        )
-        self.caching = caching
+    name = "fsspec"
+
+    def __init__(self, path: str | Path, caching: bool) -> None:
         fs = HTTPFileSystem(get_client=get_client)
-        if self.caching:
-            self.fs = CachingFileSystem(
+        if caching:
+            self.fs: HTTPFileSystem | CachingFileSystem = CachingFileSystem(
                 fs=fs,
-                # target_protocol='blockcache',
                 cache_storage=os.path.join(path, ".git", "datalad", "cache", "fsspec"),
-                # cache_check=600,
-                # block_size=1024,
-                # check_files=True,
-                # expiry_times=True,
-                # same_names=True
             )
         else:
             self.fs = fs
+        self._caching = caching
 
-    def close(self) -> None:
-        if self.annex is not None:
-            self.annex._batched.clear()
+    def can_handle(self, key: Optional[AnnexKey], mode: str) -> bool:  # noqa: U100
+        return True  # fsspec handles everything
 
-    @methodtools.lru_cache(maxsize=CACHE_SIZE)
-    def get_file_state(self, relpath: str) -> tuple[FileState, Optional[AnnexKey]]:
-        p = self.path / relpath
-        lgr.debug("get_file_state: %s", relpath)
-
-        def handle_path_under_annex_objects(
-            p: Path,
-        ) -> tuple[FileState, Optional[AnnexKey]]:
-            iadok = is_annex_dir_or_key(p)
-            if isinstance(iadok, AnnexKey):
-                if p.exists():
-                    return (FileState.HAS_CONTENT, iadok)
-                else:
-                    return (FileState.NO_CONTENT, iadok)
-            else:
-                return (FileState.NOT_ANNEXED, None)
-
-        # Shortcut handling of content under .git, in particular - annex key paths
-        if self.mode_transparent and relpath.startswith(".git/"):
-            return handle_path_under_annex_objects(p)
-
-        # A regular file or git link for which we need to explicitly ask annex about
-        if not p.is_symlink():
-            if p.stat().st_size < 1024 and self.annex is not None:
-                if self.annex.is_under_annex(relpath, batch=True):
-                    key = AnnexKey.parse(self.annex.get_file_key(relpath, batch=True))
-                    if self.annex.file_has_content(relpath, batch=True):
-                        return (FileState.HAS_CONTENT, key)
-                    else:
-                        return (FileState.NO_CONTENT, key)
-            return (FileState.NOT_ANNEXED, None)
-
-        return handle_path_under_annex_objects(
-            Path(os.path.normpath(p.parent / os.readlink(p)))
-        )
-
-    def get_urls(self, key: str) -> Iterator[str]:
-        assert self.annex is not None
-        # TODO: switch to batch=True whenever
-        # https://github.com/datalad/datalad/pull/6379 is merged/released.
-        # Will need a recent git-annex to work!
-        whereis = self.annex.whereis(key, output="full", batch=False, key=True)
-        remote_uuids = []
-        for ru, v in whereis.items():
-            remote_uuids.append(ru)
-            for u in v["urls"]:
-                if is_http_url(u):
-                    yield u
-
-        path_mixed = self.annex._batched.get(
-            "examinekey",
-            annex_options=["--format=annex/objects/${hashdirmixed}${key}/${key}\\n"],
-            path=self.annex.path,
-        )(key)
-        path_lower = self.annex._batched.get(
-            "examinekey",
-            annex_options=["--format=annex/objects/${hashdirlower}${key}/${key}\\n"],
-            path=self.annex.path,
-        )(key)
-
-        uuid2remote_url = {}
-        for r in self.annex.get_remotes():
-            ru = self.annex.config.get(f"remote.{r}.annex-uuid")
-            if ru is None:
-                continue
-            remote_url = self.annex.config.get(f"remote.{r}.url")
-            if remote_url is None:
-                continue
-            remote_url = self.annex.config.rewrite_url(remote_url)
-            uuid2remote_url[ru] = remote_url
-
-        for ru in remote_uuids:
-            try:
-                base_url = uuid2remote_url[ru]
-            except KeyError:
-                continue
-            if is_http_url(base_url):
-                if base_url.lower().rstrip("/").endswith("/.git"):
-                    paths = [path_mixed, path_lower]
-                else:
-                    paths = [
-                        path_lower,
-                        path_mixed,
-                        f".git/{path_lower}",
-                        f".git/{path_mixed}",
-                    ]
-                for p in paths:
-                    yield base_url.rstrip("/") + "/" + p
-
-    def open(
-        self,
-        relpath: str,
-        mode: str = "rb",
-        encoding: str = "utf-8",
-        errors: Optional[str] = None,
-    ) -> IO:
-        if mode not in ("r", "rb", "rt"):
-            raise NotImplementedError("Only modes 'r', 'rb', and 'rt' are supported")
-        if mode == "rb":
-            kwargs = {}
-        else:
-            kwargs = {"encoding": encoding, "errors": errors}
-        fstate, key = self.get_file_state(relpath)
-        if fstate is FileState.NOT_ANNEXED:
-            lgr.debug("%s: not under annex", relpath)
-        else:
-            lgr.debug(
-                "%s: under annex, %s content",
-                relpath,
-                "has" if fstate is FileState.HAS_CONTENT else "does not have",
+    def open_url(self, url: str, mode: str = "rb", **kwargs: Any) -> IO:
+        try:
+            return self.fs.open(url, mode, **kwargs)  # type: ignore[no-any-return]
+        except BlocksizeMismatchError as e:
+            lgr.warning(
+                "Blocksize mismatch for %s: %s; clearing cache and retrying", url, e
             )
-        if fstate is FileState.NO_CONTENT:
-            lgr.debug("%s: opening via fsspec", relpath)
-            for url in self.get_urls(str(key)):
-                try:
-                    lgr.debug("%s: Attempting to open via URL %s", relpath, url)
-                    return self.fs.open(url, mode, **kwargs)  # type: ignore
-                except BlocksizeMismatchError as e:
-                    lgr.warning(
-                        "%s: Blocksize mismatch: %s; deleting cached file and"
-                        " re-opening",
-                        relpath,
-                        e,
-                    )
-                    self.fs.pop_from_cache(url)
-                    return self.fs.open(url, mode, **kwargs)  # type: ignore
-                except FileNotFoundError as e:
-                    lgr.debug(
-                        "Failed to open file %s at URL %s: %s", relpath, url, str(e)
-                    )
-            raise IOError(
-                f"Could not find a usable URL for {relpath} within {self.path}"
-            )
-        else:
-            lgr.debug("%s: opening directly", relpath)
-            return open(self.path / relpath, mode, **kwargs)  # type: ignore
+            self.fs.pop_from_cache(url)
+            return self.fs.open(url, mode, **kwargs)  # type: ignore[no-any-return]
 
     def clear(self) -> None:
-        if self.caching:
+        if self._caching:
             self.fs.clear_cache()
 
 
-class FsspecAdapter:
-    def __init__(
-        self, root: str | Path, caching: bool, mode_transparent: bool = False
-    ) -> None:
-        self.root = Path(root)
-        self.mode_transparent = mode_transparent
-        self.caching = caching
-        self.datasets: dict[Path, DatasetAdapter] = {}
-
-    def __enter__(self) -> FsspecAdapter:
-        return self
-
-    def __exit__(
-        self,
-        _exc_type: Optional[type[BaseException]],
-        _exc_val: Optional[BaseException],
-        _exc_tb: Optional[TracebackType],
-    ) -> None:
-        for ds in self.datasets.values():
-            ds.close()
-        self.datasets.clear()
-
-    @methodtools.lru_cache(maxsize=CACHE_SIZE)
-    # TODO: optimize "caching" more since for all files under the same directory
-    # they all would belong to the same dataset
-    def get_dataset_path(self, path: str | Path) -> Path:
-        path = Path(self.root, path)
-        dspath = get_dataset_root(path)
-        if dspath is None:
-            raise ValueError(f"Path not under DataLad: {path}")
-        dspath = Path(dspath)
-        assert isinstance(dspath, Path)
-        try:
-            dspath.relative_to(self.root)
-        except ValueError:
-            raise ValueError(f"Path not under root dataset: {path}")
-        return dspath
-
-    def resolve_dataset(self, filepath: str | Path) -> tuple[DatasetAdapter, str]:
-        dspath = self.get_dataset_path(filepath)
-        try:
-            dsap = self.datasets[dspath]
-        except KeyError:
-            dsap = self.datasets[dspath] = DatasetAdapter(
-                dspath,
-                mode_transparent=self.mode_transparent,
-                caching=self.caching,
-            )
-        relpath = str(Path(filepath).relative_to(dspath))
-        return dsap, relpath
-
-    def open(
-        self,
-        filepath: str | Path,
-        mode: str = "rb",
-        encoding: str = "utf-8",
-        errors: Optional[str] = None,
-    ) -> IO:
-        dsap, relpath = self.resolve_dataset(filepath)
-        lgr.debug(
-            "%s: path resolved to %s in dataset at %s", filepath, relpath, dsap.path
-        )
-        return dsap.open(relpath, mode=mode, encoding=encoding, errors=errors)
-
-    def get_file_state(
-        self, filepath: str | Path
-    ) -> tuple[FileState, Optional[AnnexKey]]:
-        dsap, relpath = self.resolve_dataset(filepath)
-        return cast(Tuple[FileState, Optional[AnnexKey]], dsap.get_file_state(relpath))
-
-    def is_under_annex(self, filepath: str | Path) -> bool:
-        dsap, relpath = self.resolve_dataset(filepath)
-        fstate, _ = dsap.get_file_state(relpath)
-        return fstate is not FileState.NOT_ANNEXED
-
-    def get_commit_datetime(self, filepath: str | Path) -> datetime:
-        dsap, _ = self.resolve_dataset(filepath)
-        return dsap.commit_dt
-
-
-def is_http_url(s: str) -> bool:
-    return s.lower().startswith(("http://", "https://"))
+# -- Async HTTP helpers (fsspec-specific) ------------------------------------
 
 
 async def on_request_start(
@@ -308,3 +85,30 @@ async def get_client(**kwargs: Any) -> RetryClient:
         ),
         retry_options=ListRetry(timeouts=[1, 2, 6, 15, 36]),
     )
+
+
+# -- Backward compatibility --------------------------------------------------
+
+_COMPAT_MAP: dict[str, tuple[str, str]] = {
+    # Only names that existed in the pre-refactoring fsspec.py
+    # name -> (module, canonical_name)
+    "FsspecAdapter": ("datalad_fuse.adapter", "RemoteFilesystemAdapter"),
+    "DatasetAdapter": ("datalad_fuse.adapter", "DatasetAdapter"),
+    "FileState": ("datalad_fuse.adapter", "FileState"),
+    "is_http_url": ("datalad_fuse.adapter", "is_http_url"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _COMPAT_MAP:
+        module_path, canonical_name = _COMPAT_MAP[name]
+        mod = importlib.import_module(module_path)
+        obj = getattr(mod, canonical_name)
+        warnings.warn(
+            f"Importing {name!r} from 'datalad_fuse.fsspec' is deprecated. "
+            f"Use 'from {module_path} import {canonical_name}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return obj
+    raise AttributeError(f"module 'datalad_fuse.fsspec' has no attribute {name!r}")

--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -51,10 +51,12 @@ class FsspecBackend(_Backend):
     def open_url(self, url: str, mode: str = "rb", **kwargs: Any) -> IO:
         try:
             return self.fs.open(url, mode, **kwargs)  # type: ignore[no-any-return]
-        except BlocksizeMismatchError as e:
-            lgr.warning(
-                "Blocksize mismatch for %s: %s; clearing cache and retrying", url, e
-            )
+        except BlocksizeMismatchError:
+            # Eviction only makes sense for CachingFileSystem; on a plain
+            # HTTPFileSystem there is no cache to evict, so re-raise.
+            if not self._caching:
+                raise
+            lgr.warning("Blocksize mismatch for %s; clearing cache and retrying", url)
             self.fs.pop_from_cache(url)
             return self.fs.open(url, mode, **kwargs)  # type: ignore[no-any-return]
 

--- a/datalad_fuse/fsspec_cache_clear.py
+++ b/datalad_fuse/fsspec_cache_clear.py
@@ -11,7 +11,7 @@ from datalad.interface.results import get_status_dict
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
 
-from .fsspec import DatasetAdapter
+from .adapter import DatasetAdapter
 
 
 @build_doc

--- a/datalad_fuse/fsspec_head.py
+++ b/datalad_fuse/fsspec_head.py
@@ -16,7 +16,7 @@ from datalad.interface.results import get_status_dict
 from datalad.support.constraints import EnsureInt, EnsureNone, EnsureStr
 from datalad.support.param import Parameter
 
-from .fsspec import FsspecAdapter
+from .adapter import RemoteFilesystemAdapter
 
 DEFAULT_LINES = 10
 
@@ -64,6 +64,15 @@ class FsspecHead(Interface):
             doc="Path to an annexed file to show the leading contents of",
             constraints=EnsureStr(),
         ),
+        "backends": Parameter(
+            args=("--backends",),
+            doc=(
+                "Comma-separated list of backends to try for remote file"
+                " access, in priority order.  Available: remfile, fsspec."
+                "  Default: remfile,fsspec"
+            ),
+            constraints=EnsureStr() | EnsureNone(),
+        ),
     }
 
     @staticmethod
@@ -76,14 +85,18 @@ class FsspecHead(Interface):
         bytes: Optional[int] = None,
         mode_transparent: bool = False,
         caching: str | None = None,
+        backends: str | None = None,
     ) -> Iterator[Dict[str, Any]]:
         ds = require_dataset(dataset, purpose="fetch file data", check_installed=True)
         if lines is not None and bytes is not None:
             raise ValueError("'lines' and 'bytes' are mutually exclusive")
         elif lines is None and bytes is None:
             lines = DEFAULT_LINES
-        with FsspecAdapter(
-            ds.path, mode_transparent=mode_transparent, caching=caching == "ondisk"
+        with RemoteFilesystemAdapter(
+            ds.path,
+            mode_transparent=mode_transparent,
+            caching=caching == "ondisk",
+            backends=backends,
         ) as fsa:
             if not os.path.isabs(path):
                 path = os.path.join(ds.path, path)

--- a/datalad_fuse/fuse_.py
+++ b/datalad_fuse/fuse_.py
@@ -21,8 +21,8 @@ from datalad.distribution.dataset import Dataset
 from fuse import FuseOSError, Operations
 import methodtools
 
+from .adapter import RemoteFilesystemAdapter
 from .consts import CACHE_SIZE
-from .fsspec import FsspecAdapter
 
 # Make it relatively small since we are aiming for metadata records ATM
 # Seems of no real good positive net ATM
@@ -70,13 +70,20 @@ class DataLadFUSE(Operations):  # LoggingMixIn,
     _counter_offset = 1000
 
     def __init__(
-        self, root: str, caching: bool, mode_transparent: bool = False
+        self,
+        root: str,
+        caching: bool,
+        mode_transparent: bool = False,
+        backends: Optional[str] = None,
     ) -> None:
         self.root = op.realpath(root)
         self.mode_transparent = mode_transparent
         self.rwlock = Lock()
-        self._adapter = FsspecAdapter(
-            root, mode_transparent=mode_transparent, caching=caching
+        self._adapter = RemoteFilesystemAdapter(
+            root,
+            mode_transparent=mode_transparent,
+            caching=caching,
+            backends=backends,
         )
         self._fhdict: dict[int, Optional[IO[bytes]]] = {}
         # fh to fsspec_file, already opened (we are RO for now, so can just open

--- a/datalad_fuse/remfile.py
+++ b/datalad_fuse/remfile.py
@@ -1,0 +1,134 @@
+"""RemfileBackend — HDF5-optimised remote file access via the *remfile* library."""
+
+from __future__ import annotations
+
+import logging
+from types import ModuleType, TracebackType
+from typing import IO, Any, Optional, cast
+import urllib.request
+
+from .backends import Backend
+from .utils import AnnexKey
+
+lgr = logging.getLogger("datalad.fuse.remfile")
+
+
+def _get_remfile() -> Optional[ModuleType]:
+    """Lazy import of remfile; returns None if not installed."""
+    try:
+        import remfile
+
+        return remfile  # type: ignore[no-any-return]
+    except ImportError:
+        return None
+
+
+class RemfileBackend(Backend):
+    """Backend using remfile for HDF5-structured files (.nwb, .h5, etc.)."""
+
+    name = "remfile"
+
+    # File extensions this backend handles (HDF5-structured formats)
+    EXTENSIONS = frozenset({".nwb", ".h5", ".hdf5", ".hdf", ".he5", ".nc", ".nc4"})
+
+    def __init__(self) -> None:
+        remfile_mod = _get_remfile()
+        if remfile_mod is None:
+            raise ImportError("remfile is not installed")
+        self._remfile: ModuleType = remfile_mod
+
+    def can_handle(self, key: Optional[AnnexKey], mode: str) -> bool:
+        if mode != "rb":
+            return False
+        if key is None or key.suffix is None:
+            return False
+        return key.suffix.lower() in self.EXTENSIONS
+
+    def open_url(self, url: str, mode: str = "rb", **kwargs: Any) -> IO:  # noqa: U100
+        return cast(IO, RemfileWrapper(self._remfile.File(url), url))
+
+
+class RemfileWrapper:
+    """Wraps ``remfile.File`` to satisfy the contracts expected by datalad-fuse.
+
+    Adds context manager protocol, line iteration (for ``fsspec_head``), and an
+    ``info()`` method compatible with ``file_getattr`` in *fuse_.py*.
+    """
+
+    _ITER_CHUNK = 8192
+
+    def __init__(self, remfile_obj: Any, url: str) -> None:
+        self._f = remfile_obj
+        self._url = url
+        self.closed = False
+
+    def read(self, size: int = -1) -> bytes:
+        return self._f.read(size)  # type: ignore[no-any-return]
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return self._f.seek(offset, whence)  # type: ignore[no-any-return]
+
+    def tell(self) -> int:
+        return self._f.tell()  # type: ignore[no-any-return]
+
+    def close(self) -> None:
+        self._f.close()
+        self.closed = True
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def __enter__(self) -> RemfileWrapper:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: Optional[type[BaseException]],
+        _exc_val: Optional[BaseException],
+        _exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    def __iter__(self) -> RemfileWrapper:
+        return self
+
+    def __next__(self) -> bytes:
+        chunks: list[bytes] = []
+        while True:
+            chunk = self._f.read(self._ITER_CHUNK)
+            if not chunk:
+                if chunks:
+                    return b"".join(chunks)
+                raise StopIteration
+            idx = chunk.find(b"\n")
+            if idx != -1:
+                chunks.append(chunk[: idx + 1])
+                # Seek back past the bytes we read beyond the newline
+                overshoot = len(chunk) - idx - 1
+                if overshoot:
+                    self._f.seek(-overshoot, 1)
+                return b"".join(chunks)
+            chunks.append(chunk)
+
+    def info(self) -> dict[str, Any]:
+        """Minimal info dict matching the fsspec convention.
+
+        Issues a HEAD request to obtain ``Content-Length``.  This is rarely
+        called in practice because HDF5 annex keys almost always carry size
+        information.
+        """
+        req = urllib.request.Request(self._url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            content_length = resp.headers.get("Content-Length")
+        if content_length is None:
+            raise ValueError(
+                f"HEAD response for {self._url} lacks Content-Length; "
+                "cannot determine file size"
+            )
+        return {"type": "file", "size": int(content_length)}

--- a/datalad_fuse/remfile.py
+++ b/datalad_fuse/remfile.py
@@ -45,6 +45,13 @@ class RemfileBackend(Backend):
         return key.suffix.lower() in self.EXTENSIONS
 
     def open_url(self, url: str, mode: str = "rb", **kwargs: Any) -> IO:  # noqa: U100
+        if mode != "rb":
+            # Mirror can_handle()'s mode check: remfile is binary-only, so
+            # refuse text modes explicitly rather than silently returning a
+            # binary stream when called directly (bypassing can_handle()).
+            raise NotImplementedError(
+                f"RemfileBackend only supports mode='rb', got {mode!r}"
+            )
         return cast(IO, RemfileWrapper(self._remfile.File(url), url))
 
 

--- a/datalad_fuse/remfile.py
+++ b/datalad_fuse/remfile.py
@@ -56,6 +56,10 @@ class RemfileWrapper:
     """
 
     _ITER_CHUNK = 8192
+    # Hard cap on bytes returned per __next__ call.  Without this, iterating
+    # a binary file (e.g. HDF5/NWB) — which has no '\n' — would download the
+    # entire remote file in a single iteration step.
+    _MAX_LINE_BYTES = 1 << 20  # 1 MiB
 
     def __init__(self, remfile_obj: Any, url: str) -> None:
         self._f = remfile_obj
@@ -100,7 +104,8 @@ class RemfileWrapper:
 
     def __next__(self) -> bytes:
         chunks: list[bytes] = []
-        while True:
+        total = 0
+        while total < self._MAX_LINE_BYTES:
             chunk = self._f.read(self._ITER_CHUNK)
             if not chunk:
                 if chunks:
@@ -115,6 +120,10 @@ class RemfileWrapper:
                     self._f.seek(-overshoot, 1)
                 return b"".join(chunks)
             chunks.append(chunk)
+            total += len(chunk)
+        # Hit the cap without finding a newline — return what we have so the
+        # caller still makes progress instead of OOM-ing on a binary file.
+        return b"".join(chunks)
 
     def info(self) -> dict[str, Any]:
         """Minimal info dict matching the fsspec convention.

--- a/datalad_fuse/tests/test_backends.py
+++ b/datalad_fuse/tests/test_backends.py
@@ -1,0 +1,783 @@
+"""Tests for the pluggable backend system (remfile, fsspec) and adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+from datetime import datetime, timezone
+from io import BytesIO
+import logging
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import Iterator, Optional
+from unittest.mock import MagicMock, patch
+
+from fsspec.exceptions import BlocksizeMismatchError
+import pytest
+
+from datalad_fuse.adapter import (
+    DatasetAdapter,
+    FileState,
+    RemoteFilesystemAdapter,
+    create_backends,
+    is_http_url,
+    resolve_backends,
+)
+from datalad_fuse.backends import DEFAULT_BACKENDS, Backend
+from datalad_fuse.fsspec import FsspecBackend, on_request_start
+from datalad_fuse.remfile import RemfileBackend, RemfileWrapper, _get_remfile
+from datalad_fuse.utils import AnnexKey
+
+try:
+    import remfile  # noqa: F401
+
+    _has_remfile = True
+except ImportError:
+    _has_remfile = False
+
+requires_remfile = pytest.mark.skipif(not _has_remfile, reason="remfile not installed")
+
+
+# -- RemfileBackend.can_handle tests -----------------------------------------
+
+
+@requires_remfile
+class TestRemfileBackendCanHandle:
+    """Tests for RemfileBackend extension detection via can_handle."""
+
+    pytestmark = pytest.mark.ai_generated
+
+    @pytest.fixture()
+    def remfile_backend(self) -> RemfileBackend:
+        return RemfileBackend()
+
+    @pytest.mark.parametrize("ext", sorted(RemfileBackend.EXTENSIONS))
+    def test_hdf5_extensions_accepted(
+        self, remfile_backend: RemfileBackend, ext: str
+    ) -> None:
+        key = AnnexKey(backend="MD5E", name="abc123", size=100, suffix=ext)
+        assert remfile_backend.can_handle(key, "rb") is True
+
+    @pytest.mark.parametrize("ext", [".txt", ".png", ".csv", ".json", ".zip"])
+    def test_non_hdf5_extensions_rejected(
+        self, remfile_backend: RemfileBackend, ext: str
+    ) -> None:
+        key = AnnexKey(backend="MD5E", name="abc123", size=100, suffix=ext)
+        assert remfile_backend.can_handle(key, "rb") is False
+
+    def test_no_suffix_rejected(self, remfile_backend: RemfileBackend) -> None:
+        key = AnnexKey(backend="MD5", name="abc123", size=100, suffix=None)
+        assert remfile_backend.can_handle(key, "rb") is False
+
+    def test_none_key_rejected(self, remfile_backend: RemfileBackend) -> None:
+        assert remfile_backend.can_handle(None, "rb") is False
+
+    def test_case_insensitive(self, remfile_backend: RemfileBackend) -> None:
+        key = AnnexKey(backend="MD5E", name="abc123", size=100, suffix=".NWB")
+        assert remfile_backend.can_handle(key, "rb") is True
+
+    def test_text_mode_rejected(self, remfile_backend: RemfileBackend) -> None:
+        key = AnnexKey(backend="MD5E", name="abc123", size=100, suffix=".nwb")
+        assert remfile_backend.can_handle(key, "r") is False
+        assert remfile_backend.can_handle(key, "rt") is False
+
+
+class TestFsspecBackendCanHandle:
+    """FsspecBackend.can_handle always returns True."""
+
+    @pytest.mark.ai_generated
+    def test_always_true(self, tmp_path) -> None:
+        backend = FsspecBackend(tmp_path, caching=False)
+        key = AnnexKey(backend="MD5E", name="abc123", size=100, suffix=".txt")
+        assert backend.can_handle(key, "rb") is True
+        assert backend.can_handle(key, "r") is True
+        assert backend.can_handle(None, "rb") is True
+
+
+# -- ABC compliance shared across backends -----------------------------------
+
+
+def _all_backends(tmp_path) -> list[Backend]:
+    out: list[Backend] = [FsspecBackend(tmp_path, caching=False)]
+    if _has_remfile:
+        out.append(RemfileBackend())
+    return out
+
+
+@pytest.mark.ai_generated
+def test_abc_compliance(tmp_path) -> None:
+    for backend in _all_backends(tmp_path):
+        assert isinstance(backend, Backend)
+        assert isinstance(backend.name, str) and backend.name
+        assert callable(backend.can_handle)
+        assert callable(backend.open_url)
+        assert callable(backend.clear)
+
+
+# -- FsspecBackend retry on BlocksizeMismatchError ---------------------------
+
+
+@pytest.mark.ai_generated
+def test_fsspec_open_retries_on_blocksize_mismatch(tmp_path) -> None:
+    """First open() raises BlocksizeMismatchError; cache cleared; retry succeeds."""
+    backend = FsspecBackend(tmp_path, caching=False)
+    fake_fs = MagicMock()
+    good_handle = BytesIO(b"ok")
+    fake_fs.open.side_effect = [BlocksizeMismatchError("mismatch"), good_handle]
+    backend.fs = fake_fs
+    result = backend.open_url("http://example.com/x.bin")
+    assert result is good_handle
+    fake_fs.pop_from_cache.assert_called_once_with("http://example.com/x.bin")
+    assert fake_fs.open.call_count == 2
+
+
+# -- resolve_backends / create_backends tests --------------------------------
+
+
+class TestResolveBackends:
+    """Verify argument > config > default precedence.
+
+    Note: resolve_backends returns ``(spec, explicit)``.  ``explicit`` is True
+    for the argument and config paths, False for the default fallback.
+    """
+
+    pytestmark = pytest.mark.ai_generated
+
+    def test_explicit_wins(self) -> None:
+        spec, explicit = resolve_backends("fsspec")
+        assert spec == "fsspec"
+        assert explicit is True
+
+    def test_default(self, monkeypatch) -> None:
+        # Ensure config is not consulted; this returns None for any key so
+        # resolve_backends falls through to DEFAULT_BACKENDS.
+        monkeypatch.setattr(
+            "datalad_fuse.adapter.cfg.get",
+            lambda _key, default=None: default,
+        )
+        spec, explicit = resolve_backends(None)
+        assert spec == DEFAULT_BACKENDS
+        assert explicit is False
+
+    def test_config_override(self, monkeypatch) -> None:
+        get = MagicMock(return_value="fsspec")
+        monkeypatch.setattr("datalad_fuse.adapter.cfg.get", get)
+        spec, explicit = resolve_backends(None)
+        assert spec == "fsspec"
+        assert explicit is True
+        get.assert_called_once_with("datalad.fusefs.backends", None)
+
+    def test_explicit_beats_config(self, monkeypatch) -> None:
+        get = MagicMock(return_value="fsspec")
+        monkeypatch.setattr("datalad_fuse.adapter.cfg.get", get)
+        spec, explicit = resolve_backends("remfile,fsspec")
+        assert spec == "remfile,fsspec"
+        assert explicit is True
+        get.assert_not_called()
+
+
+class TestCreateBackends:
+    pytestmark = pytest.mark.ai_generated
+
+    def test_fsspec_only(self, tmp_path) -> None:
+        backends = create_backends("fsspec", tmp_path, caching=False)
+        assert len(backends) == 1
+        assert backends[0].name == "fsspec"
+
+    def test_unknown_backend_raises(self, tmp_path) -> None:
+        with pytest.raises(ValueError, match="Unknown backend"):
+            create_backends("nosuch", tmp_path, caching=False)
+
+    def test_unavailable_backend_skipped(self, tmp_path, caplog) -> None:
+        with patch("datalad_fuse.remfile._get_remfile", return_value=None):
+            backends = create_backends(
+                "remfile,fsspec", tmp_path, caching=False, explicit=False
+            )
+        # remfile skipped, fsspec remains
+        assert len(backends) == 1
+        assert backends[0].name == "fsspec"
+        # No warning when non-explicit
+        assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_unavailable_explicit_backend_warns(self, tmp_path, caplog) -> None:
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="datalad.fuse.adapter")
+        with patch("datalad_fuse.remfile._get_remfile", return_value=None):
+            backends = create_backends(
+                "remfile,fsspec", tmp_path, caching=False, explicit=True
+            )
+        assert len(backends) == 1 and backends[0].name == "fsspec"
+        assert any("remfile" in r.message for r in caplog.records)
+
+    def test_all_unavailable_raises(self, tmp_path) -> None:
+        with patch("datalad_fuse.remfile._get_remfile", return_value=None):
+            with pytest.raises(ValueError, match="No usable backends"):
+                create_backends("remfile", tmp_path, caching=False)
+
+    @requires_remfile
+    def test_order_preserved(self, tmp_path) -> None:
+        backends = create_backends("remfile,fsspec", tmp_path, caching=False)
+        assert [b.name for b in backends] == ["remfile", "fsspec"]
+
+    def test_fsspec_with_caching(self, tmp_path) -> None:
+        backends = create_backends("fsspec", tmp_path, caching=True)
+        assert len(backends) == 1
+        assert backends[0].name == "fsspec"
+        from fsspec.implementations.cached import CachingFileSystem
+
+        assert isinstance(backends[0].fs, CachingFileSystem)
+
+
+# -- is_http_url tests -------------------------------------------------------
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("http://example.com/x", True),
+        ("https://example.com/x", True),
+        ("HTTP://example.com/x", True),
+        ("HTTPS://example.com/x", True),
+        ("ftp://example.com/x", False),
+        ("file:///tmp/x", False),
+        ("", False),
+        ("/local/path", False),
+    ],
+)
+def test_is_http_url(url: str, expected: bool) -> None:
+    assert is_http_url(url) is expected
+
+
+# -- RemfileWrapper tests ----------------------------------------------------
+
+
+def _make_mock_remfile(data: bytes = b"hello world\nline two\n") -> MagicMock:
+    """Create a mock remfile.File object backed by *data*."""
+    mock = MagicMock()
+    pos = [0]
+
+    def read(size: int = -1) -> bytes:
+        if size == -1:
+            result = data[pos[0] :]
+            pos[0] = len(data)
+            return result
+        result = data[pos[0] : pos[0] + size]
+        pos[0] = min(pos[0] + size, len(data))
+        return result
+
+    def seek(offset: int, whence: int = 0) -> int:
+        if whence == 0:
+            pos[0] = offset
+        elif whence == 1:
+            pos[0] += offset
+        elif whence == 2:
+            pos[0] = len(data) + offset
+        return pos[0]
+
+    def tell() -> int:
+        return pos[0]
+
+    mock.read = read
+    mock.seek = seek
+    mock.tell = tell
+    mock.close = MagicMock()
+    return mock
+
+
+class TestRemfileWrapper:
+    """Tests for the RemfileWrapper adapter class."""
+
+    pytestmark = pytest.mark.ai_generated
+
+    def test_read(self) -> None:
+        mock_rf = _make_mock_remfile(b"abcdef")
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        assert w.read(3) == b"abc"
+        assert w.read(3) == b"def"
+
+    def test_seek_and_tell(self) -> None:
+        mock_rf = _make_mock_remfile(b"abcdef")
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        w.seek(3)
+        assert w.tell() == 3
+        assert w.read(2) == b"de"
+
+    def test_context_manager(self) -> None:
+        mock_rf = _make_mock_remfile()
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        assert not w.closed
+        with w as f:
+            assert f is w
+        assert w.closed
+        mock_rf.close.assert_called_once()
+
+    def test_iteration(self) -> None:
+        mock_rf = _make_mock_remfile(b"line one\nline two\nline three")
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        assert list(w) == [b"line one\n", b"line two\n", b"line three"]
+
+    def test_iteration_empty(self) -> None:
+        mock_rf = _make_mock_remfile(b"")
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        assert list(w) == []
+
+    def test_close(self) -> None:
+        mock_rf = _make_mock_remfile()
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        w.close()
+        assert w.closed
+        mock_rf.close.assert_called_once()
+
+    def test_io_protocol_methods(self) -> None:
+        mock_rf = _make_mock_remfile()
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        assert w.readable() is True
+        assert w.seekable() is True
+        assert w.writable() is False
+
+    def test_info_success(self, monkeypatch) -> None:
+        """info() returns {'type': 'file', 'size': N} when Content-Length present."""
+        fake_resp = MagicMock()
+        fake_resp.headers = {"Content-Length": "1234"}
+        fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+        fake_resp.__exit__ = MagicMock(return_value=None)
+        monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=fake_resp))
+        w = RemfileWrapper(_make_mock_remfile(), "http://example.com/test.h5")
+        assert w.info() == {"type": "file", "size": 1234}
+
+    def test_info_missing_content_length(self, monkeypatch) -> None:
+        """info() raises ValueError when Content-Length header absent."""
+        fake_resp = MagicMock()
+        fake_resp.headers = {}
+        fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+        fake_resp.__exit__ = MagicMock(return_value=None)
+        monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=fake_resp))
+        w = RemfileWrapper(_make_mock_remfile(), "http://example.com/test.h5")
+        with pytest.raises(ValueError, match="Content-Length"):
+            w.info()
+
+
+# -- DatasetAdapter backend-chain and RemoteFilesystemAdapter tests ----------
+
+
+class _StubBackend(Backend):
+    """In-memory backend for exercising DatasetAdapter.open fallback."""
+
+    def __init__(
+        self,
+        name: str,
+        can_handle_result: bool = True,
+        open_result: Optional[bytes] = None,
+        raises: Optional[Exception] = None,
+    ) -> None:
+        self.name = name
+        self._can = can_handle_result
+        self._open_result = open_result
+        self._raises = raises
+        self.open_calls: list[str] = []
+        self.clear_calls = 0
+
+    def can_handle(self, key, mode: str) -> bool:  # noqa: U100
+        return self._can
+
+    def open_url(self, url: str, mode: str = "rb", **kwargs):  # noqa: U100
+        self.open_calls.append(url)
+        if self._raises is not None:
+            raise self._raises
+        return BytesIO(self._open_result or b"")
+
+    def clear(self) -> None:
+        self.clear_calls += 1
+
+
+def _make_dataset_adapter_with_backends(
+    tmp_path, backends: list[Backend], urls: list[str]
+) -> DatasetAdapter:
+    """Build a DatasetAdapter whose file-state + URL generator are stubbed."""
+    # Bypass __init__ (which requires a real datalad dataset on disk)
+    adapter = DatasetAdapter.__new__(DatasetAdapter)
+    adapter.path = tmp_path
+    adapter.mode_transparent = False
+    adapter.annex = None
+    adapter._backends = backends
+
+    key = AnnexKey(backend="MD5E", name="abc123", size=100, suffix=".nwb")
+
+    def fake_get_file_state(_relpath: str):
+        return (FileState.NO_CONTENT, key)
+
+    def fake_get_urls(_key: str) -> Iterator[str]:
+        yield from urls
+
+    adapter.get_file_state = fake_get_file_state  # type: ignore[method-assign]
+    adapter.get_urls = fake_get_urls  # type: ignore[method-assign]
+    return adapter
+
+
+@pytest.mark.ai_generated
+class TestDatasetAdapterOpen:
+    """Exercise the backend-chain fallback semantics in DatasetAdapter.open."""
+
+    def test_first_backend_succeeds(self, tmp_path) -> None:
+        a = _StubBackend("a", open_result=b"hello")
+        b = _StubBackend("b", open_result=b"world")
+        adapter = _make_dataset_adapter_with_backends(tmp_path, [a, b], ["http://u1"])
+        handle = adapter.open("x.nwb")
+        assert handle.read() == b"hello"
+        assert a.open_calls == ["http://u1"]
+        assert b.open_calls == []
+
+    def test_falls_through_to_next_backend(self, tmp_path) -> None:
+        boom = _StubBackend("boom", raises=FileNotFoundError("nope"))
+        ok = _StubBackend("ok", open_result=b"good")
+        adapter = _make_dataset_adapter_with_backends(
+            tmp_path, [boom, ok], ["http://u1"]
+        )
+        handle = adapter.open("x.nwb")
+        assert handle.read() == b"good"
+        assert boom.open_calls == ["http://u1"]
+        assert ok.open_calls == ["http://u1"]
+
+    def test_skips_backend_that_cannot_handle(self, tmp_path) -> None:
+        skipper = _StubBackend(
+            "skip", can_handle_result=False, raises=RuntimeError("!")
+        )
+        ok = _StubBackend("ok", open_result=b"good")
+        adapter = _make_dataset_adapter_with_backends(
+            tmp_path, [skipper, ok], ["http://u1"]
+        )
+        handle = adapter.open("x.nwb")
+        assert handle.read() == b"good"
+        # Skipper must not have been asked to open anything.
+        assert skipper.open_calls == []
+        assert ok.open_calls == ["http://u1"]
+
+    def test_all_fail_raises_ioerror_with_cause(self, tmp_path) -> None:
+        last_exc = FileNotFoundError("last")
+        a = _StubBackend("a", raises=FileNotFoundError("first"))
+        b = _StubBackend("b", raises=last_exc)
+        adapter = _make_dataset_adapter_with_backends(tmp_path, [a, b], ["http://u1"])
+        with pytest.raises(IOError) as exc_info:
+            adapter.open("x.nwb")
+        assert exc_info.value.__cause__ is last_exc
+        assert "a,b" in str(exc_info.value)
+
+    def test_non_http_urls_still_tried_per_backend(self, tmp_path) -> None:
+        """All provided URLs are tried in order until one succeeds."""
+        a = _StubBackend(
+            "a",
+            raises=FileNotFoundError("no"),
+        )
+        # With multiple URLs, backend is retried for each.
+        adapter = _make_dataset_adapter_with_backends(
+            tmp_path, [a], ["http://u1", "http://u2"]
+        )
+        with pytest.raises(IOError):
+            adapter.open("x.nwb")
+        assert a.open_calls == ["http://u1", "http://u2"]
+
+    def test_clear_delegates_to_backends(self, tmp_path) -> None:
+        a = _StubBackend("a")
+        b = _StubBackend("b")
+        adapter = _make_dataset_adapter_with_backends(tmp_path, [a, b], [])
+        adapter.clear()
+        assert a.clear_calls == 1
+        assert b.clear_calls == 1
+
+    def test_unsupported_mode_raises(self, tmp_path) -> None:
+        adapter = _make_dataset_adapter_with_backends(tmp_path, [_StubBackend("a")], [])
+        with pytest.raises(NotImplementedError, match="modes"):
+            adapter.open("x.nwb", mode="wb")
+
+    @pytest.mark.parametrize("mode", ["r", "rt"])
+    def test_text_mode_forwards_encoding(self, tmp_path, mode) -> None:
+        """Mode 'r'/'rt' should pass encoding/errors through to backend.open_url."""
+        captured: dict = {}
+
+        class CapturingBackend(Backend):
+            name = "cap"
+
+            def can_handle(self, key, mode_):  # noqa: U100
+                return True
+
+            def open_url(self, url, mode_="rb", **kwargs):  # noqa: U100
+                captured.update(kwargs)
+                return BytesIO(b"")
+
+            def clear(self):
+                pass
+
+        adapter = _make_dataset_adapter_with_backends(
+            tmp_path, [CapturingBackend()], ["http://u1"]
+        )
+        adapter.open("x.nwb", mode=mode, encoding="latin-1", errors="replace")
+        assert captured == {"encoding": "latin-1", "errors": "replace"}
+
+    def test_generic_exception_falls_through(self, tmp_path) -> None:
+        """A non-FileNotFoundError (e.g. RuntimeError) should still fall through."""
+        boom = _StubBackend("boom", raises=RuntimeError("wat"))
+        ok = _StubBackend("ok", open_result=b"fallback")
+        adapter = _make_dataset_adapter_with_backends(
+            tmp_path, [boom, ok], ["http://u1"]
+        )
+        handle = adapter.open("x.nwb")
+        assert handle.read() == b"fallback"
+        assert boom.open_calls == ["http://u1"]
+        assert ok.open_calls == ["http://u1"]
+
+    def test_not_annexed_opens_local(self, tmp_path) -> None:
+        """NOT_ANNEXED files are opened directly from disk."""
+        (tmp_path / "local.txt").write_text("direct read")
+        adapter = DatasetAdapter.__new__(DatasetAdapter)
+        adapter.path = tmp_path
+        adapter.mode_transparent = False
+        adapter.annex = None
+        adapter._backends = []
+        adapter.get_file_state = lambda _r: (  # type: ignore[method-assign]
+            FileState.NOT_ANNEXED,
+            None,
+        )
+        with adapter.open("local.txt", mode="r") as f:
+            assert f.read() == "direct read"
+
+
+@pytest.mark.ai_generated
+class TestRemoteFilesystemAdapterLifecycle:
+    """Context-manager semantics: __exit__ closes datasets and empties the dict."""
+
+    def test_exit_closes_datasets(self, tmp_path) -> None:
+        rfs = RemoteFilesystemAdapter(tmp_path, caching=False)
+        ds_a = MagicMock()
+        ds_b = MagicMock()
+        rfs.datasets = {tmp_path / "a": ds_a, tmp_path / "b": ds_b}
+        with rfs:
+            pass
+        ds_a.close.assert_called_once()
+        ds_b.close.assert_called_once()
+        assert rfs.datasets == {}
+
+    def test_exit_closes_even_on_exception(self, tmp_path) -> None:
+        rfs = RemoteFilesystemAdapter(tmp_path, caching=False)
+        ds_a = MagicMock()
+        rfs.datasets = {tmp_path / "a": ds_a}
+        with pytest.raises(RuntimeError):
+            with rfs:
+                raise RuntimeError("boom")
+        ds_a.close.assert_called_once()
+        assert rfs.datasets == {}
+
+    def test_get_dataset_path_not_datalad(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("datalad_fuse.adapter.get_dataset_root", lambda _p: None)
+        rfs = RemoteFilesystemAdapter(tmp_path, caching=False)
+        with pytest.raises(ValueError, match="not under DataLad"):
+            rfs.get_dataset_path("anything")
+
+    def test_get_dataset_path_outside_root(self, tmp_path, monkeypatch) -> None:
+        other = tmp_path.parent / "elsewhere"
+        monkeypatch.setattr(
+            "datalad_fuse.adapter.get_dataset_root", lambda _p: str(other)
+        )
+        rfs = RemoteFilesystemAdapter(tmp_path, caching=False)
+        with pytest.raises(ValueError, match="not under root dataset"):
+            rfs.get_dataset_path("x")
+
+    def test_delegation_to_dataset_adapter(self, tmp_path) -> None:
+        """get_file_state, is_under_annex, get_commit_datetime delegate to DS."""
+        rfs = RemoteFilesystemAdapter(tmp_path, caching=False)
+        fake_ds = MagicMock()
+        dt = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        fake_ds.commit_dt = dt
+        fake_ds.get_file_state.return_value = (FileState.HAS_CONTENT, None)
+        rfs.resolve_dataset = lambda _p: (fake_ds, "rel")  # type: ignore[method-assign]
+
+        assert rfs.get_file_state("x") == (FileState.HAS_CONTENT, None)
+        assert rfs.is_under_annex("x") is True
+        assert rfs.get_commit_datetime("x") == dt
+
+        fake_ds.get_file_state.return_value = (FileState.NOT_ANNEXED, None)
+        assert rfs.is_under_annex("x") is False
+
+    def test_resolve_dataset_reuses_cached_adapter(self, tmp_path, monkeypatch) -> None:
+        """resolve_dataset caches DatasetAdapter instances by dataset path."""
+        monkeypatch.setattr(
+            "datalad_fuse.adapter.get_dataset_root", lambda p: str(Path(p).parent)
+        )
+        rfs = RemoteFilesystemAdapter(tmp_path, caching=False)
+        # Pre-populate so __init__ isn't invoked (no real dataset)
+        prebuilt = MagicMock()
+        dspath = tmp_path
+        rfs.datasets[dspath] = prebuilt
+        (tmp_path / "a.txt").write_text("x")
+        dsap1, rel1 = rfs.resolve_dataset(tmp_path / "a.txt")
+        dsap2, _ = rfs.resolve_dataset(tmp_path / "a.txt")
+        assert dsap1 is prebuilt is dsap2
+        assert rel1 == "a.txt"
+
+
+# -- FsspecBackend additional coverage ---------------------------------------
+
+
+@pytest.mark.ai_generated
+def test_fsspec_clear_with_caching(tmp_path) -> None:
+    """FsspecBackend.clear() calls fs.clear_cache() when caching=True."""
+    backend = FsspecBackend(tmp_path, caching=True)
+    backend.fs = MagicMock()
+    backend._caching = True
+    backend.clear()
+    backend.fs.clear_cache.assert_called_once()
+
+
+@pytest.mark.ai_generated
+def test_fsspec_clear_without_caching_noop(tmp_path) -> None:
+    """FsspecBackend.clear() is a no-op when caching=False."""
+    backend = FsspecBackend(tmp_path, caching=False)
+    backend.fs = MagicMock()
+    backend.clear()
+    backend.fs.clear_cache.assert_not_called()
+
+
+@pytest.mark.ai_generated
+def test_on_request_start_logs_retry(caplog) -> None:
+    """on_request_start emits a warning for attempts beyond the first."""
+    caplog.set_level(logging.WARNING, logger="datalad.fuse.fsspec")
+    ctx = SimpleNamespace(trace_request_ctx={"current_attempt": 2})
+    params = SimpleNamespace(url="http://example.com")
+    asyncio.run(on_request_start(MagicMock(), ctx, params))
+    assert any("Retrying" in r.message for r in caplog.records)
+
+    caplog.clear()
+    ctx.trace_request_ctx["current_attempt"] = 1
+    asyncio.run(on_request_start(MagicMock(), ctx, params))
+    assert not any("Retrying" in r.message for r in caplog.records)
+
+
+# -- RemfileBackend availability detection -----------------------------------
+
+
+@pytest.mark.ai_generated
+def test_remfile_backend_raises_when_unavailable(monkeypatch) -> None:
+    """RemfileBackend.__init__ raises ImportError when remfile is not installed."""
+    monkeypatch.setattr("datalad_fuse.remfile._get_remfile", lambda: None)
+    with pytest.raises(ImportError, match="remfile"):
+        RemfileBackend()
+
+
+@pytest.mark.ai_generated
+def test_get_remfile_returns_none_on_import_error(monkeypatch) -> None:
+    """_get_remfile() swallows ImportError and returns None."""
+    # Block remfile from being imported: shadow sys.modules so the
+    # next `import remfile` fails, and shadow __import__ to guarantee
+    # ImportError is raised even if remfile was cached.
+    monkeypatch.setitem(sys.modules, "remfile", None)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "remfile":
+            raise ImportError("not here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert _get_remfile() is None
+
+
+# -- Integration tests with real S3 URLs -------------------------------------
+
+# Pinned versions from dandiarchive S3 bucket
+S3_HDF5_URL = (
+    "https://dandiarchive.s3.amazonaws.com/ros3test.hdf5"
+    "?versionId=_8Zs6qF7E6vpc5BcPOhizlFBY2oHCN8T"
+)
+S3_NWB_URL = (
+    "https://dandiarchive.s3.amazonaws.com/ros3test.nwb"
+    "?versionId=jRN4ejAcjOAaFDXTQrO99WCZqTxhZL32"
+)
+S3_README_URL = (
+    "https://dandiarchive.s3.amazonaws.com/README.md"
+    "?versionId=mAywZ4KP9BCgGIERb3DtlPzTWYv.5sUi"
+)
+
+
+@requires_remfile
+class TestIntegrationRemfileBackend:
+    """Integration tests using real S3 URLs via the RemfileBackend."""
+
+    pytestmark = [pytest.mark.ai_generated, pytest.mark.network]
+
+    @pytest.fixture()
+    def remfile_backend(self) -> RemfileBackend:
+        return RemfileBackend()
+
+    def test_open_hdf5(self, remfile_backend: RemfileBackend) -> None:
+        with remfile_backend.open_url(S3_HDF5_URL) as f:
+            assert f.read(8) == b"\x89HDF\r\n\x1a\n"
+
+    def test_open_nwb(self, remfile_backend: RemfileBackend) -> None:
+        with remfile_backend.open_url(S3_NWB_URL) as f:
+            assert f.read(8) == b"\x89HDF\r\n\x1a\n"
+
+    def test_seek_and_reread(self, remfile_backend: RemfileBackend) -> None:
+        with remfile_backend.open_url(S3_HDF5_URL) as f:
+            first = f.read(8)
+            f.seek(0)
+            second = f.read(8)
+            assert first == second == b"\x89HDF\r\n\x1a\n"
+
+    def test_wrapper_context_manager(self, remfile_backend: RemfileBackend) -> None:
+        f = remfile_backend.open_url(S3_HDF5_URL)
+        with f:
+            assert f.read(4) == b"\x89HDF"
+        assert f.closed
+
+
+class TestIntegrationFsspecBackend:
+    """Integration tests using real S3 URLs via the FsspecBackend."""
+
+    pytestmark = [pytest.mark.ai_generated, pytest.mark.network]
+
+    @pytest.fixture()
+    def fsspec_backend(self, tmp_path) -> FsspecBackend:
+        return FsspecBackend(tmp_path, caching=False)
+
+    def test_open_readme(self, fsspec_backend: FsspecBackend) -> None:
+        with fsspec_backend.open_url(S3_README_URL) as f:
+            data = f.read(100)
+            assert len(data) > 0
+            assert isinstance(data, bytes)
+
+    def test_open_hdf5(self, fsspec_backend: FsspecBackend) -> None:
+        with fsspec_backend.open_url(S3_HDF5_URL) as f:
+            assert f.read(8) == b"\x89HDF\r\n\x1a\n"
+
+
+@requires_remfile
+class TestIntegrationBackendChain:
+    """Test backend chain selection logic."""
+
+    pytestmark = pytest.mark.ai_generated
+
+    def test_remfile_selected_for_hdf5(self, tmp_path) -> None:
+        backends = create_backends("remfile,fsspec", tmp_path, caching=False)
+        key = AnnexKey(backend="MD5E", name="abc", size=100, suffix=".hdf5")
+        for b in backends:
+            if b.can_handle(key, "rb"):
+                assert b.name == "remfile"
+                break
+
+    def test_fsspec_selected_for_md(self, tmp_path) -> None:
+        backends = create_backends("remfile,fsspec", tmp_path, caching=False)
+        key = AnnexKey(backend="MD5E", name="abc", size=100, suffix=".md")
+        for b in backends:
+            if b.can_handle(key, "rb"):
+                assert b.name == "fsspec"
+                break
+
+    def test_fsspec_only_chain(self, tmp_path) -> None:
+        backends = create_backends("fsspec", tmp_path, caching=False)
+        key = AnnexKey(backend="MD5E", name="abc", size=100, suffix=".nwb")
+        for b in backends:
+            if b.can_handle(key, "rb"):
+                assert b.name == "fsspec"
+                break

--- a/datalad_fuse/tests/test_backends.py
+++ b/datalad_fuse/tests/test_backends.py
@@ -121,7 +121,7 @@ def test_abc_compliance(tmp_path) -> None:
 @pytest.mark.ai_generated
 def test_fsspec_open_retries_on_blocksize_mismatch(tmp_path) -> None:
     """First open() raises BlocksizeMismatchError; cache cleared; retry succeeds."""
-    backend = FsspecBackend(tmp_path, caching=False)
+    backend = FsspecBackend(tmp_path, caching=True)
     fake_fs = MagicMock()
     good_handle = BytesIO(b"ok")
     fake_fs.open.side_effect = [BlocksizeMismatchError("mismatch"), good_handle]
@@ -130,6 +130,20 @@ def test_fsspec_open_retries_on_blocksize_mismatch(tmp_path) -> None:
     assert result is good_handle
     fake_fs.pop_from_cache.assert_called_once_with("http://example.com/x.bin")
     assert fake_fs.open.call_count == 2
+
+
+@pytest.mark.ai_generated
+def test_fsspec_open_propagates_blocksize_mismatch_without_caching(tmp_path) -> None:
+    """With caching=False there is no cache to evict; the error must propagate
+    instead of attempting pop_from_cache (which would AttributeError on a
+    plain HTTPFileSystem)."""
+    backend = FsspecBackend(tmp_path, caching=False)
+    fake_fs = MagicMock(spec=["open"])  # no pop_from_cache attribute
+    fake_fs.open.side_effect = BlocksizeMismatchError("mismatch")
+    backend.fs = fake_fs
+    with pytest.raises(BlocksizeMismatchError):
+        backend.open_url("http://example.com/x.bin")
+    assert fake_fs.open.call_count == 1
 
 
 # -- resolve_backends / create_backends tests --------------------------------
@@ -188,6 +202,22 @@ class TestCreateBackends:
     def test_unknown_backend_raises(self, tmp_path) -> None:
         with pytest.raises(ValueError, match="Unknown backend"):
             create_backends("nosuch", tmp_path, caching=False)
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "fsspec,,fsspec",  # double comma
+            "fsspec, ,fsspec",  # comma + whitespace
+            "fsspec,",  # trailing comma
+            ",fsspec",  # leading comma
+            " fsspec , fsspec ",  # internal/external whitespace
+        ],
+    )
+    def test_empty_entries_tolerated(self, tmp_path, spec) -> None:
+        """Stray commas and whitespace in the spec are silently skipped."""
+        backends = create_backends(spec, tmp_path, caching=False)
+        assert all(b.name == "fsspec" for b in backends)
+        assert len(backends) >= 1
 
     def test_unavailable_backend_skipped(self, tmp_path, caplog) -> None:
         with patch("datalad_fuse.remfile._get_remfile", return_value=None):

--- a/datalad_fuse/tests/test_backends.py
+++ b/datalad_fuse/tests/test_backends.py
@@ -82,6 +82,20 @@ class TestRemfileBackendCanHandle:
         assert remfile_backend.can_handle(key, "r") is False
         assert remfile_backend.can_handle(key, "rt") is False
 
+    @pytest.mark.parametrize("mode", ["r", "rt", "w", "wb"])
+    def test_open_url_rejects_non_binary_mode(
+        self, remfile_backend: RemfileBackend, mode: str
+    ) -> None:
+        """open_url() refuses non-'rb' modes even when called directly.
+
+        ``can_handle()`` already returns False for these, so the backend chain
+        will never call open_url() with such a mode in practice — but if a
+        caller bypasses can_handle() we want a loud failure rather than a
+        silently-binary handle.
+        """
+        with pytest.raises(NotImplementedError, match="mode='rb'"):
+            remfile_backend.open_url("http://example.com/x.h5", mode=mode)
+
 
 class TestFsspecBackendCanHandle:
     """FsspecBackend.can_handle always returns True."""

--- a/datalad_fuse/tests/test_backends.py
+++ b/datalad_fuse/tests/test_backends.py
@@ -354,6 +354,23 @@ class TestRemfileWrapper:
         w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
         assert list(w) == []
 
+    def test_iteration_caps_no_newline(self) -> None:
+        """Binary data without '\\n' must not cause runaway reads.
+
+        The wrapper caps each ``__next__`` at ``_MAX_LINE_BYTES`` so iterating
+        an HDF5 file does not download the whole remote object.
+        """
+        # 3 chunks worth of newline-less bytes (well below 1 MiB cap so the
+        # test stays fast); shrink the cap for the assertion.
+        data = b"x" * (3 * RemfileWrapper._ITER_CHUNK)
+        mock_rf = _make_mock_remfile(data)
+        w = RemfileWrapper(mock_rf, "http://example.com/test.h5")
+        # Patch the cap to 2 chunks so we can verify the bound takes effect.
+        w._MAX_LINE_BYTES = 2 * RemfileWrapper._ITER_CHUNK
+        first = next(iter(w))
+        assert len(first) == 2 * RemfileWrapper._ITER_CHUNK
+        assert b"\n" not in first
+
     def test_close(self) -> None:
         mock_rf = _make_mock_remfile()
         w = RemfileWrapper(mock_rf, "http://example.com/test.h5")

--- a/datalad_fuse/tests/test_deprecations.py
+++ b/datalad_fuse/tests/test_deprecations.py
@@ -1,0 +1,55 @@
+"""Verify old datalad_fuse.fsspec import paths still work with warnings."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+from datalad_fuse.fsspec import _COMPAT_MAP
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "old_name,module_path,canonical_name",
+    [(name, mod, canon) for name, (mod, canon) in _COMPAT_MAP.items()],
+    ids=list(_COMPAT_MAP),
+)
+def test_compat_import_warns(old_name, module_path, canonical_name):
+    """Moved names imported from datalad_fuse.fsspec emit DeprecationWarning."""
+    import datalad_fuse.fsspec as fsspec_mod
+
+    with pytest.warns(DeprecationWarning, match=old_name):
+        obj = getattr(fsspec_mod, old_name)
+
+    canonical_mod = importlib.import_module(module_path)
+    assert obj is getattr(canonical_mod, canonical_name)
+
+
+@pytest.mark.ai_generated
+def test_unknown_attr_raises():
+    import datalad_fuse.fsspec as fsspec_mod
+
+    # Direct attribute access raises AttributeError (module-level __getattr__).
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(AttributeError, match="no_such_name"):
+            fsspec_mod.no_such_name  # noqa: B018
+
+
+@pytest.mark.ai_generated
+def test_unknown_attr_from_import_raises():
+    # `from x import y` on a missing name converts AttributeError to ImportError.
+    with pytest.raises(ImportError):
+        from datalad_fuse.fsspec import (  # type: ignore[attr-defined]  # noqa: F401
+            no_such_name,
+        )
+
+
+@pytest.mark.ai_generated
+def test_fsspec_backend_no_warning():
+    """FsspecBackend still lives in fsspec.py — no deprecation."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        from datalad_fuse.fsspec import FsspecBackend  # noqa: F401

--- a/datalad_fuse/tests/test_forgejo.py
+++ b/datalad_fuse/tests/test_forgejo.py
@@ -12,7 +12,7 @@ import subprocess
 import pytest
 import requests
 
-from datalad_fuse.fsspec import DatasetAdapter, _is_aneksajo
+from datalad_fuse.adapter import DatasetAdapter, _is_aneksajo
 
 from .conftest_forgejo import (
     ForgejoInstance,

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,10 @@ include_package_data = True
 include = datalad_fuse*
 
 [options.extras_require]
+full =
+    datalad-fuse[remfile]
+remfile =
+    remfile
 test =
     coverage~=6.0
     linesep~=0.2

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,12 @@ python =
 passenv =
     HOME
     DATALAD_*
-extras = test
+extras =
+    test
+    # `full` pulls in optional backends (e.g. remfile).  Installed for any
+    # env whose factors include `full` or `libfuse` so both py314-full
+    # (FUSE + network) and py314-libfuse (FUSE only) exercise them.
+    full,libfuse: full
 # Factor: full — enable --libfuse and --network tests.
 # Combine with any pyXY, e.g. py314-full, py312-full.
 # Without "full", pytest_configure() sets bogus HTTP proxies to catch
@@ -56,8 +61,11 @@ deps =
 extras = test
 commands =
     mypy --follow-imports skip \
+        datalad_fuse/adapter.py \
+        datalad_fuse/backends.py \
         datalad_fuse/fsspec.py \
         datalad_fuse/fuse_.py \
+        datalad_fuse/remfile.py \
         datalad_fuse/utils.py
 
 [pytest]
@@ -75,6 +83,7 @@ norecursedirs = datalad_fuse/tests/data
 markers =
     libfuse: FUSE tests; only run when --libfuse is given
     network: tests that hit the public network; only run when --network is given
+    ai_generated: tests authored by an AI assistant
 
 [coverage:run]
 branch = True

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,11 @@ python =
 passenv =
     HOME
     DATALAD_*
-extras = test
+extras =
+    test
+    # `full` pulls in optional backends (e.g. remfile).  Always installed
+    # so backend unit tests run even when network/forgejo are disabled.
+    full
 # Factors:
 #   nonetwork — disable network tests (sets bogus proxies to catch leaks)
 #   full      — also enable --libfuse tests
@@ -58,8 +62,11 @@ deps =
 extras = test
 commands =
     mypy --follow-imports skip \
+        datalad_fuse/adapter.py \
+        datalad_fuse/backends.py \
         datalad_fuse/fsspec.py \
         datalad_fuse/fuse_.py \
+        datalad_fuse/remfile.py \
         datalad_fuse/utils.py
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,11 @@ passenv =
     DATALAD_*
 extras =
     test
-    # `full` pulls in optional backends (e.g. remfile).  Always installed
-    # so backend unit tests run even when network/forgejo are disabled.
-    full
+    # `full` pulls in optional backends (e.g. remfile).  Installed only in
+    # envs whose name carries `full` or `libfuse`, so the default
+    # `py3{10..14}-nonetwork` rows stay lean and remfile remains optional.
+    # Tests that require remfile are gated by a `requires_remfile` skipif.
+    full,libfuse: full
 # Factors:
 #   nonetwork — disable network tests (sets bogus proxies to catch leaks)
 #   full      — also enable --libfuse tests


### PR DESCRIPTION
## Summary

- Add pluggable backend system for remote file access with `--backends` CLI option (comma-separated, priority-ordered)
- Add `remfile` backend (optional `pip install datalad-fuse[remfile]`) optimized for HDF5 access patterns (.nwb, .h5, .hdf5, etc.)
- Refactor monolithic `fsspec.py` into focused modules: `backends.py` (ABC), `remfile.py`, `adapter.py`, slimmed `fsspec.py`
- Preserve backward compatibility for old `datalad_fuse.fsspec` import paths via `DeprecationWarning`

### How it works

The backend chain walks `--backends=remfile,fsspec` (default) in order. Each backend's `can_handle(key, mode)` decides if it should handle a file based on the annex key's extension. First match tries all URLs; on failure, falls through to the next backend. Configuration via `--backends` flag, `datalad.fusefs.backends` config variable, or programmatic API.

### New module layout

| Module | Contents |
|---|---|
| `backends.py` | `Backend` ABC,`DEFAULT_BACKENDS` |
| `remfile.py` | `RemfileBackend`, `RemfileWrapper` |
| `adapter.py` | `RemoteFilesystemAdapter` (renamed from `FsspecAdapter`), `DatasetAdapter`, `FileState` |
| `fsspec.py` | `FsspecBackend`, HTTP helpers, backward-compat `__getattr__` |

### Commits

- f8cc531 `RF: address code review findings`
- 3dfd2d0 `TST: add backward compatibility deprecation tests`
- 990eae0 `ENH: add remfile backend with pluggable backend architecture`

## Test plan

- [ ] Manual testing
- [ ] Unit tests pass: `pytest datalad_fuse/tests/test_backends.py datalad_fuse/tests/test_deprecations.py -k "not network"`
- [ ] Integration tests with pinned S3 objects (ros3test.hdf5, ros3test.nwb, README.md): `pytest datalad_fuse/tests/test_backends.py -k network`
- [ ] Existing tests unaffected: `pytest datalad_fuse/tests/test_util.py`
- [ ] Backward compat: old `from datalad_fuse.fsspec import FsspecAdapter` still works with DeprecationWarning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Overall it grew larger than initial quick "fix" was (first commit) since the whole setup had 'fsspec' naming throughout it.