### PR TITLE
ENH: add S3 exporttree URL fallback for legacy annex exported OpenNeuro datasets

### DIFF
--- a/datalad_fuse/fsspec.py
+++ b/datalad_fuse/fsspec.py
@@ -7,11 +7,15 @@ import logging
 import os
 import os.path
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace, TracebackType
 from typing import IO, Any, Optional, Tuple, cast
 
 import aiohttp
 from aiohttp_retry import ListRetry, RetryClient
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config as BotocoreConfig
 from datalad.distribution.dataset import Dataset
 from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import get_dataset_root
@@ -152,6 +156,234 @@ class DatasetAdapter:
                 for p in paths:
                     yield base_url.rstrip("/") + "/" + p
 
+    @methodtools.lru_cache(maxsize=1)
+    def _get_exporttree_remotes(self) -> list[dict[str, str]]:
+        """Get S3 exporttree remotes with public URLs.
+
+        Parses the git-annex branch remote.log once (cached per
+        DatasetAdapter instance) to find S3 special remotes configured
+        with ``exporttree=yes`` and a usable ``publicurl``.
+
+        This is a workaround for legacy datasets that lack proper
+        versioned S3 URLs in their git-annex metadata.
+        See https://github.com/OpenNeuroOrg/openneuro/issues/3875
+
+        Returns
+        -------
+        list of dict
+            Each dict has keys: ``uuid``, ``publicurl``, ``fileprefix``,
+            ``bucket``, ``host``.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(self.path), "show", "git-annex:remote.log"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            lgr.debug("Could not read git-annex:remote.log for %s", self.path)
+            return []
+
+        remotes: list[dict[str, str]] = []
+        for line in result.stdout.strip().splitlines():
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            uuid = parts[0]
+            config: dict[str, str] = {}
+            for token in parts[1:]:
+                if "=" in token:
+                    k, v = token.split("=", 1)
+                    config[k] = v
+            if (
+                config.get("type") == "S3"
+                and config.get("exporttree") == "yes"
+                and config.get("publicurl", "no").startswith("http")
+            ):
+                remotes.append(
+                    {
+                        "uuid": uuid,
+                        "publicurl": config["publicurl"].rstrip("/"),
+                        "fileprefix": config.get("fileprefix", ""),
+                        "bucket": config.get("bucket", ""),
+                        "host": config.get("host", "s3.amazonaws.com"),
+                    }
+                )
+        return remotes
+
+    @staticmethod
+    def _list_s3_versions(
+        bucket: str,
+        object_key: str,
+        host: str = "s3.amazonaws.com",
+    ) -> list[dict[str, Any]]:
+        """List all S3 object versions for a key.
+
+        Uses ``boto3`` to call ``ListObjectVersions`` with anonymous
+        credentials (for public buckets).
+
+        Parameters
+        ----------
+        bucket : str
+            S3 bucket name (e.g., ``openneuro.org``).
+        object_key : str
+            Full object key including fileprefix (e.g.,
+            ``ds000113/sub-01/.../bold.nii.gz``).
+        host : str
+            S3 endpoint hostname (default: ``s3.amazonaws.com``).
+
+        Returns
+        -------
+        list of dict
+            Each dict has keys: ``VersionId``, ``Size``, ``ETag``,
+            ``IsLatest``.
+        """
+        try:
+            endpoint_url = f"https://{host}"
+            client = boto3.client(
+                "s3",
+                endpoint_url=endpoint_url,
+                config=BotocoreConfig(signature_version=UNSIGNED),
+            )
+            response = client.list_object_versions(
+                Bucket=bucket, Prefix=object_key
+            )
+        except Exception as e:
+            lgr.debug(
+                "Failed to list S3 versions for %s/%s: %s",
+                bucket, object_key, e,
+            )
+            return []
+
+        versions: list[dict[str, Any]] = []
+        for v in response.get("Versions", []):
+            # Only include exact key matches (prefix query may return others)
+            if v.get("Key") == object_key:
+                versions.append(
+                    {
+                        "VersionId": v.get("VersionId", ""),
+                        "Size": v.get("Size", 0),
+                        "ETag": v.get("ETag", ""),
+                        "IsLatest": v.get("IsLatest", False),
+                    }
+                )
+        return versions
+
+    @staticmethod
+    def _match_s3_version(
+        versions: list[dict[str, Any]], expected_size: int
+    ) -> Optional[str]:
+        """Match the correct S3 object version by file size.
+
+        Parameters
+        ----------
+        versions : list of dict
+            S3 version list from :meth:`_list_s3_versions`.
+        expected_size : int
+            Expected file size from ``AnnexKey.size``.
+
+        Returns
+        -------
+        str or None
+            Matched versionId, or ``None`` if no version matches.
+
+        Raises
+        ------
+        ValueError
+            If multiple versions match by size but have different ETags
+            (ambiguous content — refuse to guess).
+        """
+        matches = [v for v in versions if v["Size"] == expected_size]
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return str(matches[0]["VersionId"])
+        # Multiple matches — check ETags
+        etags = {v["ETag"] for v in matches}
+        if len(etags) == 1:
+            # Same content uploaded multiple times; prefer the latest
+            for v in matches:
+                if v["IsLatest"]:
+                    return str(v["VersionId"])
+            return str(matches[0]["VersionId"])
+        raise ValueError(
+            f"Ambiguous S3 versions: {len(matches)} versions match size "
+            f"{expected_size} but have {len(etags)} distinct ETags. "
+            f"Cannot determine correct version."
+        )
+
+    def get_exporttree_urls(
+        self, relpath: str, key: AnnexKey
+    ) -> Iterator[str]:
+        """Yield versioned URLs for file on S3 exporttree remotes.
+
+        Workaround for datasets lacking proper versioned URLs in
+        git-annex metadata. Constructs URLs from the remote's
+        ``publicurl`` + ``fileprefix`` and resolves the correct S3
+        object version by matching ``key.size``.
+
+        Parameters
+        ----------
+        relpath : str
+            File path relative to dataset root (tree path).
+        key : AnnexKey
+            Annex key with expected file size for version matching.
+
+        Yields
+        ------
+        str
+            Versioned HTTP URLs (``...?versionId=...``) or unversioned
+            URLs as fallback.
+        """
+        remotes = self._get_exporttree_remotes()
+        if not remotes:
+            return
+
+        for remote in remotes:
+            publicurl = remote["publicurl"]
+            fileprefix = remote["fileprefix"]
+            bucket = remote["bucket"]
+            host = remote["host"]
+            object_key = f"{fileprefix}{relpath}"
+            base_url = f"{publicurl}/{object_key}"
+
+            if key.size is not None:
+                versions = self._list_s3_versions(bucket, object_key, host)
+                if versions:
+                    try:
+                        version_id = self._match_s3_version(
+                            versions, key.size
+                        )
+                    except ValueError as e:
+                        lgr.warning(
+                            "%s: %s", relpath, e
+                        )
+                        continue
+                    if version_id:
+                        yield f"{base_url}?versionId={version_id}"
+                        continue
+                    else:
+                        lgr.debug(
+                            "%s: no S3 version matches size %d at %s",
+                            relpath,
+                            key.size,
+                            base_url,
+                        )
+                        continue
+
+            # Fallback: no size info or version listing failed —
+            # try unversioned URL (returns latest version)
+            lgr.warning(
+                "%s: falling back to unversioned S3 URL %s "
+                "(cannot verify correct version)",
+                relpath,
+                base_url,
+            )
+            yield base_url
+
     def open(
         self,
         relpath: str,
@@ -193,6 +425,31 @@ class DatasetAdapter:
                     lgr.debug(
                         "Failed to open file %s at URL %s: %s", relpath, url, str(e)
                     )
+            # Fallback: try S3 exporttree URLs (workaround for datasets
+            # lacking proper versioned URLs — see openneuro#3875)
+            if key is not None:
+                for url in self.get_exporttree_urls(relpath, key):
+                    try:
+                        lgr.debug(
+                            "%s: Attempting exporttree URL %s", relpath, url
+                        )
+                        return self.fs.open(url, mode, **kwargs)  # type: ignore
+                    except BlocksizeMismatchError as e:
+                        lgr.warning(
+                            "%s: Blocksize mismatch: %s; deleting cached file"
+                            " and re-opening",
+                            relpath,
+                            e,
+                        )
+                        self.fs.pop_from_cache(url)
+                        return self.fs.open(url, mode, **kwargs)  # type: ignore
+                    except FileNotFoundError as e:
+                        lgr.debug(
+                            "Failed to open file %s at exporttree URL %s: %s",
+                            relpath,
+                            url,
+                            str(e),
+                        )
             raise IOError(
                 f"Could not find a usable URL for {relpath} within {self.path}"
             )

--- a/datalad_fuse/tests/test_exporttree.py
+++ b/datalad_fuse/tests/test_exporttree.py
@@ -1,0 +1,348 @@
+"""Tests for S3 exporttree URL fallback in DatasetAdapter.
+
+Tests cover:
+- remote.log parsing (_get_exporttree_remotes)
+- S3 version listing via boto3 (_list_s3_versions)
+- Version matching by size (_match_s3_version)
+- URL construction (get_exporttree_urls)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datalad_fuse.fsspec import DatasetAdapter
+from datalad_fuse.utils import AnnexKey
+
+
+# --- remote.log parsing ---
+
+
+SAMPLE_REMOTE_LOG = (  # noqa: B950
+    "66a7004d-a15e-4764-90cd-54bbd179f74a"
+    " autoenable=true bucket=openneuro-private datacenter=US"
+    " encryption=none exporttree=yes fileprefix=ds001473/"
+    " host=s3.amazonaws.com name=s3-PRIVATE partsize=1GiB"
+    " port=80 public=no publicurl=no storageclass=STANDARD"
+    " type=S3 versioning=yes timestamp=1541104695.225259256s\n"
+    "e28d70a7-9314-4542-a4ce-7d95b862070f"
+    " autoenable=true bucket=openneuro.org datacenter=US"
+    " encryption=none exporttree=yes fileprefix=ds000113/"
+    " host=s3.amazonaws.com name=s3-PUBLIC partsize=1GiB"
+    " port=80 public=yes"
+    " publicurl=https://s3.amazonaws.com/openneuro.org"
+    " storageclass=STANDARD type=S3 versioning=yes"
+    " timestamp=1597694369.712881988s\n"
+    "b8b60a40-f339-4ddc-b08a-2a6f645bd3ef"
+    " timestamp=1541104695.225259256s\n"
+    "00000000-0000-0000-0000-000000000001"
+    " type=web timestamp=1234567890s\n"
+)
+
+
+@pytest.fixture
+def adapter():
+    """Create a DatasetAdapter with mocked internals for unit testing."""
+    da = object.__new__(DatasetAdapter)
+    da.path = "/fake/dataset"
+    da.annex = None
+    da.caching = False
+    return da
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_remotes_parsing(adapter):
+    """Parse remote.log with mixed remote types."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=SAMPLE_REMOTE_LOG, returncode=0)
+        remotes = adapter._get_exporttree_remotes()
+
+    # Only s3-PUBLIC should match (has publicurl starting with http)
+    assert len(remotes) == 1
+    assert remotes[0]["uuid"] == "e28d70a7-9314-4542-a4ce-7d95b862070f"
+    assert remotes[0]["publicurl"] == "https://s3.amazonaws.com/openneuro.org"
+    assert remotes[0]["fileprefix"] == "ds000113/"
+    assert remotes[0]["bucket"] == "openneuro.org"
+    assert remotes[0]["host"] == "s3.amazonaws.com"
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_remotes_no_remotes(adapter):
+    """Empty list when no exporttree remotes exist."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            stdout="b8b60a40 timestamp=1234s\n", returncode=0
+        )
+        remotes = adapter._get_exporttree_remotes()
+
+    assert remotes == []
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_remotes_git_failure(adapter):
+    """Graceful handling when git-annex branch is not available."""
+    import subprocess
+
+    with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "git")):
+        remotes = adapter._get_exporttree_remotes()
+
+    assert remotes == []
+
+
+# --- S3 version listing (boto3) ---
+
+
+SAMPLE_BOTO3_VERSIONS_RESPONSE = {
+    "Versions": [
+        {
+            "Key": "ds000113/sub-01/anat/sub-01_T1w.nii.gz",
+            "VersionId": "abc123",
+            "IsLatest": True,
+            "Size": 12345678,
+            "ETag": '"d41d8cd98f00b204e9800998ecf8427e"',
+        },
+        {
+            "Key": "ds000113/sub-01/anat/sub-01_T1w.nii.gz",
+            "VersionId": "def456",
+            "IsLatest": False,
+            "Size": 9999999,
+            "ETag": '"aabbccdd00112233"',
+        },
+        {
+            # Different key — should be filtered out
+            "Key": "ds000113/sub-01/anat/sub-01_T1w.nii.gz.bak",
+            "VersionId": "ignored",
+            "IsLatest": True,
+            "Size": 12345678,
+            "ETag": '"ffffffff"',
+        },
+    ]
+}
+
+
+@pytest.mark.ai_generated
+def test_list_s3_versions_parsing():
+    """Parse boto3 list_object_versions response correctly."""
+    mock_client = MagicMock()
+    mock_client.list_object_versions.return_value = SAMPLE_BOTO3_VERSIONS_RESPONSE
+
+    with patch("boto3.client", return_value=mock_client):
+        versions = DatasetAdapter._list_s3_versions(
+            "openneuro.org",
+            "ds000113/sub-01/anat/sub-01_T1w.nii.gz",
+        )
+
+    # Should have 2 versions (the .bak key is filtered out)
+    assert len(versions) == 2
+    assert versions[0]["VersionId"] == "abc123"
+    assert versions[0]["Size"] == 12345678
+    assert versions[0]["IsLatest"] is True
+    assert versions[1]["VersionId"] == "def456"
+    assert versions[1]["Size"] == 9999999
+
+
+@pytest.mark.ai_generated
+def test_list_s3_versions_network_error():
+    """Graceful handling of network errors."""
+    mock_client = MagicMock()
+    mock_client.list_object_versions.side_effect = Exception("timeout")
+
+    with patch("boto3.client", return_value=mock_client):
+        versions = DatasetAdapter._list_s3_versions(
+            "openneuro.org",
+            "ds000113/sub-01/anat/sub-01_T1w.nii.gz",
+        )
+
+    assert versions == []
+
+
+@pytest.mark.ai_generated
+def test_list_s3_versions_custom_host():
+    """Verify custom S3 endpoint host is used."""
+    mock_client = MagicMock()
+    mock_client.list_object_versions.return_value = {"Versions": []}
+
+    with patch("boto3.client", return_value=mock_client) as mock_factory:
+        DatasetAdapter._list_s3_versions(
+            "my-bucket",
+            "some/key.txt",
+            host="storage.googleapis.com",
+        )
+
+    call_kwargs = mock_factory.call_args
+    assert call_kwargs[1]["endpoint_url"] == "https://storage.googleapis.com"
+
+
+# --- Version matching ---
+
+
+@pytest.mark.ai_generated
+def test_match_s3_version_single():
+    """One version matches size — return it."""
+    versions = [
+        {"VersionId": "abc", "Size": 100, "ETag": '"aaa"', "IsLatest": True},
+        {"VersionId": "def", "Size": 200, "ETag": '"bbb"', "IsLatest": False},
+    ]
+    assert DatasetAdapter._match_s3_version(versions, 100) == "abc"
+
+
+@pytest.mark.ai_generated
+def test_match_s3_version_no_match():
+    """No version matches size — return None."""
+    versions = [
+        {"VersionId": "abc", "Size": 100, "ETag": '"aaa"', "IsLatest": True},
+    ]
+    assert DatasetAdapter._match_s3_version(versions, 999) is None
+
+
+@pytest.mark.ai_generated
+def test_match_s3_version_same_etag():
+    """Multiple versions match size, same ETag — prefer latest."""
+    versions = [
+        {"VersionId": "old", "Size": 100, "ETag": '"aaa"', "IsLatest": False},
+        {"VersionId": "new", "Size": 100, "ETag": '"aaa"', "IsLatest": True},
+    ]
+    assert DatasetAdapter._match_s3_version(versions, 100) == "new"
+
+
+@pytest.mark.ai_generated
+def test_match_s3_version_same_etag_no_latest():
+    """Multiple versions match size, same ETag, none marked latest."""
+    versions = [
+        {"VersionId": "v1", "Size": 100, "ETag": '"aaa"', "IsLatest": False},
+        {"VersionId": "v2", "Size": 100, "ETag": '"aaa"', "IsLatest": False},
+    ]
+    # Should return first one when no latest
+    assert DatasetAdapter._match_s3_version(versions, 100) == "v1"
+
+
+@pytest.mark.ai_generated
+def test_match_s3_version_different_etags():
+    """Multiple versions match size, different ETags — raise ValueError."""
+    versions = [
+        {"VersionId": "v1", "Size": 100, "ETag": '"aaa"', "IsLatest": False},
+        {"VersionId": "v2", "Size": 100, "ETag": '"bbb"', "IsLatest": True},
+    ]
+    with pytest.raises(ValueError, match="Ambiguous S3 versions"):
+        DatasetAdapter._match_s3_version(versions, 100)
+
+
+@pytest.mark.ai_generated
+def test_match_s3_version_empty():
+    """Empty version list — return None."""
+    assert DatasetAdapter._match_s3_version([], 100) is None
+
+
+# --- URL construction ---
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_urls_construction(adapter):
+    """Verify URL construction with version matching."""
+    key = AnnexKey(backend="SHA256E", name="abc123", size=12345678, suffix=".nii.gz")
+
+    versions = [
+        {"VersionId": "ver1", "Size": 12345678, "ETag": '"aaa"', "IsLatest": True},
+    ]
+
+    with (
+        patch.object(
+            adapter,
+            "_get_exporttree_remotes",
+            return_value=[
+                {
+                    "uuid": "test-uuid",
+                    "publicurl": "https://s3.amazonaws.com/openneuro.org",
+                    "fileprefix": "ds000113/",
+                    "bucket": "openneuro.org",
+                    "host": "s3.amazonaws.com",
+                }
+            ],
+        ),
+        patch.object(
+            DatasetAdapter, "_list_s3_versions", return_value=versions
+        ),
+    ):
+        urls = list(adapter.get_exporttree_urls("sub-01/anat/sub-01_T1w.nii.gz", key))
+
+    assert len(urls) == 1
+    assert urls[0] == (
+        "https://s3.amazonaws.com/openneuro.org/"
+        "ds000113/sub-01/anat/sub-01_T1w.nii.gz"
+        "?versionId=ver1"
+    )
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_urls_no_remotes(adapter):
+    """Empty when no exporttree remotes configured."""
+    key = AnnexKey(backend="SHA256E", name="abc123", size=100, suffix=".nii.gz")
+
+    with patch.object(adapter, "_get_exporttree_remotes", return_value=[]):
+        urls = list(adapter.get_exporttree_urls("sub-01/anat/sub-01_T1w.nii.gz", key))
+
+    assert urls == []
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_urls_no_size_fallback(adapter):
+    """Falls back to unversioned URL when key has no size."""
+    key = AnnexKey(backend="SHA256", name="abc123", size=None)
+
+    with patch.object(
+        adapter,
+        "_get_exporttree_remotes",
+        return_value=[
+            {
+                "uuid": "test-uuid",
+                "publicurl": "https://s3.amazonaws.com/openneuro.org",
+                "fileprefix": "ds000113/",
+                "bucket": "openneuro.org",
+                "host": "s3.amazonaws.com",
+            }
+        ],
+    ):
+        urls = list(adapter.get_exporttree_urls("sub-01/anat/sub-01_T1w.nii.gz", key))
+
+    assert len(urls) == 1
+    assert "?versionId=" not in urls[0]
+    assert urls[0] == (
+        "https://s3.amazonaws.com/openneuro.org/"
+        "ds000113/sub-01/anat/sub-01_T1w.nii.gz"
+    )
+
+
+@pytest.mark.ai_generated
+def test_get_exporttree_urls_ambiguous_skips(adapter):
+    """Ambiguous versions (different ETags) skips that remote."""
+    key = AnnexKey(backend="SHA256E", name="abc123", size=100, suffix=".nii.gz")
+
+    versions = [
+        {"VersionId": "v1", "Size": 100, "ETag": '"aaa"', "IsLatest": False},
+        {"VersionId": "v2", "Size": 100, "ETag": '"bbb"', "IsLatest": True},
+    ]
+
+    with (
+        patch.object(
+            adapter,
+            "_get_exporttree_remotes",
+            return_value=[
+                {
+                    "uuid": "test-uuid",
+                    "publicurl": "https://s3.amazonaws.com/openneuro.org",
+                    "fileprefix": "ds000113/",
+                    "bucket": "openneuro.org",
+                    "host": "s3.amazonaws.com",
+                }
+            ],
+        ),
+        patch.object(
+            DatasetAdapter, "_list_s3_versions", return_value=versions
+        ),
+    ):
+        urls = list(adapter.get_exporttree_urls("sub-01/anat/sub-01_T1w.nii.gz", key))
+
+    # Ambiguous → skipped, no URLs yielded
+    assert urls == []

--- a/docs/designs/20260408-s3-exporttree-url-fallback.md
+++ b/docs/designs/20260408-s3-exporttree-url-fallback.md
@@ -1,0 +1,362 @@
+# S3 Exporttree URL Fallback
+
+**Date**: 2026-04-08
+**Status**: Planning
+**Authors**: Yaroslav Halchenko, Claude
+
+## Summary
+
+Some legacy OpenNeuro datasets lack proper versioned S3 URLs in their git-annex
+metadata ([openneuro#3875]). While the underlying issue will be fixed directly in
+the datasets, `datalad-fuse` needs a workaround so `DatasetAdapter.open()` can
+access files on S3 exporttree remotes when `get_urls()` yields no working URLs.
+
+The workaround constructs candidate URLs from the remote's `publicurl` +
+`fileprefix` config, then resolves the correct S3 object version by matching
+file size (from the annex key) against available versionIds.
+
+## Context / Problem Statement
+
+### Current `get_urls()` flow (fsspec.py:102-153)
+
+1. **whereis URLs**: Queries `annex.whereis(key)` and yields HTTP URLs from
+   `v["urls"]`. Normally S3 remotes DO provide versioned URLs here. However, a
+   limited set of legacy datasets have incorrect/missing `git annex export`
+   state, so `urls` is empty for those.
+
+2. **Remote URL construction**: Iterates `annex.get_remotes()`, reads
+   `remote.{r}.url` from git config, and constructs annex object paths
+   (`annex/objects/{hash}/{key}`). S3 special remotes have **no `.url` entry** in
+   `.git/config` — they have `annex-s3 = true` and `annex-uuid` only. So they're
+   silently skipped.
+
+For the affected datasets, both paths fail, and `open()` raises `IOError`.
+
+### S3 exporttree remotes
+
+With `exporttree=yes`, git-annex exports files to S3 at their **tree path**
+(not their annex key hash path). Given remote config:
+
+```
+publicurl = https://s3.amazonaws.com/openneuro.org
+fileprefix = ds000113/
+exporttree = yes
+versioning = yes
+```
+
+A file at tree path `sub-01/anat/sub-01_T1w.nii.gz` is accessible at:
+```
+https://s3.amazonaws.com/openneuro.org/ds000113/sub-01/anat/sub-01_T1w.nii.gz
+```
+
+This config is stored in the `git-annex` branch's `remote.log`, not in
+`.git/config`.
+
+### S3 versioning complication
+
+The unversioned URL may have **multiple object versions** with different content.
+The latest version is typically correct for HEAD checkouts, but not necessarily
+for older checkout trees. We must:
+
+1. List all S3 versionIds for the object
+2. Match by file size (from the annex key, via `AnnexKey.size`)
+3. If exactly one size match → use that versionId
+4. If multiple matches with the **same ETag** → any is fine (identical content
+   uploaded multiple times, thus multiple versionIds)
+5. If multiple matches with **different ETags** → error (ambiguous, don't guess)
+6. If zero matches → no usable version
+
+### Affected datasets
+
+A limited set of legacy OpenNeuro datasets where `s3-PUBLIC` has
+`exporttree=yes` but per-file versioned URLs were not properly registered.
+Confirmed: ds000113, ds001499, ds001506, ds006623. See [openneuro#3875] for
+upstream fix.
+
+[openneuro#3875]: https://github.com/OpenNeuroOrg/openneuro/issues/3875
+
+### Key design constraint
+
+`get_urls(key)` receives an **annex key**, but exporttree URLs require the
+**tree path**. The tree path is available in `open(relpath)` which calls
+`get_urls(str(key))`. So the fix must either:
+- Pass `relpath` through to URL construction, or
+- Add a separate exporttree URL method called from `open()`
+
+## Proposed Solution
+
+### 1. Add `_get_exporttree_remotes()` to `DatasetAdapter`
+
+Lazily parse `git-annex:remote.log` once per `DatasetAdapter` instance (cached).
+Extract S3 remotes with `publicurl` (not `"no"`) and `exporttree=yes`.
+
+```python
+@methodtools.lru_cache(maxsize=1)
+def _get_exporttree_remotes(self) -> list[dict[str, str]]:
+    """Get S3 exporttree remotes with public URLs.
+
+    Parses git-annex branch remote.log once (cached).
+
+    Returns:
+        List of dicts with keys: uuid, publicurl, fileprefix, bucket
+    """
+```
+
+`remote.log` format (one remote per line):
+```
+UUID key1=value1 key2=value2 ... timestamp=Ns
+```
+
+Filter criteria: `type=S3` AND `publicurl` starts with `http` AND `exporttree=yes`.
+
+### 2. Add `_list_s3_versions()` to `DatasetAdapter`
+
+Query S3 for all versions of an object at a given key prefix.
+
+```python
+def _list_s3_versions(
+    self, bucket_url: str, object_key: str
+) -> list[dict[str, str]]:
+    """List all S3 object versions for a key.
+
+    Uses S3 REST API: GET /{bucket}?versions&prefix={key}
+
+    Args:
+        bucket_url: S3 bucket URL (e.g., https://s3.amazonaws.com/openneuro.org)
+        object_key: Full object key (e.g., ds000113/sub-01/.../bold.nii.gz)
+
+    Returns:
+        List of dicts with keys: VersionId, Size, ETag, IsLatest
+    """
+```
+
+### 3. Add `_match_s3_version()` to `DatasetAdapter`
+
+Match the correct version by file size from the annex key.
+
+```python
+def _match_s3_version(
+    self, versions: list[dict[str, str]], expected_size: int
+) -> str | None:
+    """Match S3 object version by file size.
+
+    Args:
+        versions: S3 version list from _list_s3_versions()
+        expected_size: Expected file size from AnnexKey.size
+
+    Returns:
+        versionId string, or None if no match
+
+    Raises:
+        ValueError: If multiple versions match size with different ETags
+            (ambiguous — refuse to guess)
+    """
+```
+
+Algorithm:
+1. Filter versions where `int(Size) == expected_size`
+2. If 0 → return None
+3. If 1 → return its VersionId
+4. If N, collect unique ETags among matches
+5. If all same ETag → return any VersionId (prefer IsLatest=true)
+6. If different ETags → raise ValueError (ambiguous)
+
+### 4. Add `get_exporttree_urls(relpath, key)` to `DatasetAdapter`
+
+```python
+def get_exporttree_urls(
+    self, relpath: str, key: AnnexKey
+) -> Iterator[str]:
+    """Yield versioned URLs for file on S3 exporttree remotes.
+
+    Args:
+        relpath: File path relative to dataset root (tree path)
+        key: AnnexKey with expected size for version matching
+
+    Yields:
+        Versioned HTTP URLs: {publicurl}/{fileprefix}{relpath}?versionId={id}
+    """
+```
+
+Logic:
+1. Get cached exporttree remote configs
+2. For each remote:
+   a. Construct object key: `{fileprefix}{relpath}`
+   b. List S3 versions for that key
+   c. Match version by `key.size`
+   d. Yield `{publicurl}/{fileprefix}{relpath}?versionId={matched_id}`
+3. If version listing fails or no match, fall back to unversioned URL
+   (latest version) with a warning
+
+### 5. Modify `open()` to try exporttree URLs as fallback
+
+In `open()` (line 177-198), after `get_urls(key)` exhausts all candidates
+without success, try `get_exporttree_urls(relpath, key)` before raising `IOError`:
+
+```python
+if fstate is FileState.NO_CONTENT:
+    lgr.debug("%s: opening via fsspec", relpath)
+    for url in self.get_urls(str(key)):
+        try:
+            ...
+            return self.fs.open(url, mode, **kwargs)
+        except FileNotFoundError as e:
+            ...
+
+    # Fallback: try S3 exporttree URLs (workaround for datasets
+    # lacking proper versioned URLs — see openneuro#3875)
+    if key is not None:
+        for url in self.get_exporttree_urls(relpath, key):
+            try:
+                lgr.debug("%s: Attempting exporttree URL %s", relpath, url)
+                return self.fs.open(url, mode, **kwargs)
+            except FileNotFoundError as e:
+                lgr.debug(
+                    "Failed to open file %s at exporttree URL %s: %s",
+                    relpath, url, str(e)
+                )
+
+    raise IOError(
+        f"Could not find a usable URL for {relpath} within {self.path}"
+    )
+```
+
+## Implementation Details
+
+### Parsing `remote.log`
+
+Use datalad's existing git infrastructure rather than raw subprocess where
+possible. Fallback:
+
+```python
+import subprocess
+
+result = subprocess.run(
+    ["git", "-C", str(self.path), "show", "git-annex:remote.log"],
+    capture_output=True, text=True, check=True,
+)
+```
+
+Each line: `UUID key=value key=value ... timestamp=...s`
+
+Parse by splitting on spaces, then splitting each token on first `=`.
+Handle edge cases:
+- Multiple `timestamp=` entries (take last)
+- Values with `=` in them (split on first `=` only)
+- Empty/comment lines
+
+### S3 version listing
+
+Use the S3 REST API (works for public buckets without auth):
+
+```
+GET https://s3.amazonaws.com/{bucket}?versions&prefix={object_key}
+```
+
+Returns XML with `<Version>` elements containing `Key`, `VersionId`, `Size`,
+`ETag`, `IsLatest`, `LastModified`.
+
+Use the existing `aiohttp`/`fsspec` HTTP infrastructure — or a simple
+synchronous `urllib.request` since this is a metadata query, not a data transfer.
+
+Parse with `xml.etree.ElementTree` (stdlib, no new dependencies).
+
+### URL construction
+
+```python
+publicurl = config["publicurl"].rstrip("/")
+fileprefix = config.get("fileprefix", "")
+object_key = f"{fileprefix}{relpath}"
+# Unversioned
+url = f"{publicurl}/{object_key}"
+# Versioned
+url = f"{publicurl}/{object_key}?versionId={version_id}"
+```
+
+Note: `fileprefix` in OpenNeuro already includes trailing slash (e.g.,
+`ds000113/`). Be defensive — handle both with and without.
+
+## Test Plan
+
+### Unit tests
+
+1. **`test_get_exporttree_remotes_parsing`**: Mock `remote.log` content with
+   mixed remote types (S3 with publicurl, S3 without, directory, web). Verify
+   only the correct remotes are returned.
+
+2. **`test_get_exporttree_urls_construction`**: Given known remote config, verify
+   URL construction for various relpaths.
+
+3. **`test_get_exporttree_urls_no_remotes`**: Verify empty iterator when no
+   exporttree remotes exist (no-op for non-S3 datasets).
+
+4. **`test_match_s3_version_single`**: One version matches size → return it.
+
+5. **`test_match_s3_version_same_etag`**: Multiple versions match size, same
+   ETag → return any (prefer latest).
+
+6. **`test_match_s3_version_different_etags`**: Multiple versions match size,
+   different ETags → raise ValueError.
+
+7. **`test_match_s3_version_no_match`**: No version matches size → return None.
+
+8. **`test_open_falls_back_to_exporttree`**: Mock `get_urls()` to yield no
+   working URLs, mock `get_exporttree_urls()` to yield a working URL. Verify
+   `open()` succeeds via the fallback.
+
+9. **`test_list_s3_versions_parsing`**: Mock S3 XML response, verify parsing of
+   VersionId, Size, ETag fields.
+
+### Integration tests (if feasible)
+
+Test against an actual OpenNeuro dataset clone (e.g., ds000113) — requires
+network access and a populated `.git/annex` branch.
+
+## Alternatives Considered
+
+### A. Extend `get_urls(key, relpath=None)`
+
+Add optional `relpath` parameter to `get_urls()`. Pro: single method. Con:
+changes the API signature, mixes two different URL resolution strategies (key-based
+vs path-based) in one method.
+
+### B. Use `git annex info REMOTE --json` per remote
+
+Pro: uses official git-annex interface. Con: one subprocess call per remote (3-5
+calls per dataset), slower than parsing `remote.log` once.
+
+### C. Use DataLad's `AnnexRepo` API for special remote config
+
+Pro: no raw subprocess calls. Con: unclear if the API exposes `publicurl` /
+`exporttree` from the git-annex branch — these aren't standard git config values.
+Would need investigation into DataLad internals.
+
+### D. Skip version matching, just use unversioned URL
+
+Pro: much simpler. Con: wrong content for older checkout trees. The user may be
+working with a historical commit where the latest S3 version doesn't match.
+
+### E. Fix upstream in OpenNeuro only (no datalad-fuse change)
+
+Being pursued ([openneuro#3875]) but will take time to fix all legacy datasets.
+The datalad-fuse workaround enables immediate access.
+
+## Success Criteria
+
+1. `DatasetAdapter.open("sub-01/anat/sub-01_T1w.nii.gz")` succeeds for
+   datasets with S3 exporttree remotes (e.g., OpenNeuro ds000113)
+2. Correct version selected: file size matches `AnnexKey.size`
+3. Ambiguous versions (different ETags, same size) produce a clear error
+4. No performance regression for datasets that already have working URLs
+   (exporttree lookup is lazy/cached and only triggered as fallback)
+5. All existing tests continue to pass
+6. New unit tests cover parsing, version matching, URL construction, and
+   fallback behavior
+
+## References
+
+- [openneuro#3875]: S3 VersionId'ed URLs missing from git-annex
+- OpenNeuro S3 remote config: `bucket=openneuro.org`, `publicurl=https://s3.amazonaws.com/openneuro.org`, `exporttree=yes`
+- git-annex special remote protocol: https://git-annex.branchable.com/special_remotes/
+- git-annex exporttree: https://git-annex.branchable.com/git-annex-export/
+- S3 ListObjectVersions API: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
 python_requires = >= 3.9
 install_requires =
     aiohttp-retry ~= 2.8
+    boto3
     datalad >= 0.17.0
     fsspec[fuse,http] >= 2022.1.0, != 2022.10.0
     fusepy


### PR DESCRIPTION
Workaround for datasets lacking proper versioned S3 URLs in git-annex metadata (see https://github.com/OpenNeuroOrg/openneuro/issues/3875). Constructs URLs from remote.log config (publicurl + fileprefix) and resolves correct S3 object version by matching file size from AnnexKey.

- Add _get_exporttree_remotes() to parse git-annex:remote.log
- Add _list_s3_versions() using boto3 for anonymous S3 access
- Add _match_s3_version() with size/ETag disambiguation
- Add get_exporttree_urls() to yield versioned URLs
- Fall back to exporttree URLs in open() when whereis URLs fail
- Add boto3 to install_requires
- Mark all new tests with @pytest.mark.ai_generated